### PR TITLE
🔇 Denoiser: Add recurring rejection rules to CONSISTENTLY_IGNORED.md

### DIFF
--- a/.jules/CONSISTENTLY_IGNORED.md
+++ b/.jules/CONSISTENTLY_IGNORED.md
@@ -1,0 +1,29 @@
+## IGNORE: Unscoped File Deletions & Mass Refactoring
+
+**- Pattern:** Deleting files, commands, or documentation sections (like `AGENTS.md` or `TEMPLATES.md`) that are completely unrelated to the explicit task (e.g., while adding a SARIF upload feature).
+**- Justification:** Expanding scope to delete unrelated code or documentation introduces massive risk and violates the core directive of scope discipline.
+**- Files Affected:** `*` (Any file not directly related to the requested feature)
+
+## IGNORE: Downgrading CI/CD Actions and Dependencies
+
+**- Pattern:** Downgrading GitHub Action versions (e.g., `actions/checkout` to v4 from v5, or `peter-evans/create-pull-request` to v6 from v8).
+**- Justification:** Reverting dependencies to older major versions introduces regressions, undoes security/pinning updates, and violates global instructions not to downgrade unless explicitly requested.
+**- Files Affected:** `.github/workflows/*.yml`
+
+## IGNORE: Hallucinated Dependency Versions
+
+**- Pattern:** Bumping tool versions to non-existent or hallucinated future versions (e.g., Node.js v25.6.1, golangci-lint v2.10.1).
+**- Justification:** Automated updates to versions that don't actually exist break the build environment and demonstrate a lack of real-world validation.
+**- Files Affected:** `mise.toml`, `go.mod`
+
+## IGNORE: Unhandled Errors in Go Code
+
+**- Pattern:** Ignoring error returns from standard I/O or formatting functions without explicitly checking them (e.g., `fmt.Fprintln`, `fmt.Fprintf`, `resp.Body.Close()`).
+**- Justification:** Project conventions mandate that Go code must explicitly handle all errors. Introducing new unhandled errors will fail the strict linter checks and violate core guidelines.
+**- Files Affected:** `*.go`
+
+## IGNORE: Improper CLI Output Formatting (Replacing Prints with slog)
+
+**- Pattern:** Replacing user-facing CLI instructions or generic interactive prints with structured logging (e.g., swapping `fmt.Printf` with `slog.Info` for user messages).
+**- Justification:** Structured logging (`slog`) is strictly for machine-readable application logs. Standard human-facing instructions and prompts must use `stderr` (e.g., `fmt.Fprint(os.Stderr, ...)`). Conflating the two breaks CLI UX.
+**- Files Affected:** `cmd/**/*.go`


### PR DESCRIPTION
### Description
Analyzed recent rejected pull requests and formalized the failure patterns into actionable rules in `.jules/CONSISTENTLY_IGNORED.md`.

**Rules Added:**
1. **Unscoped File Deletions & Mass Refactoring**: Prevents agents from deleting unrelated code/documentation (like `AGENTS.md`) while working on a separate feature (e.g., SARIF uploads).
2. **Downgrading CI/CD Actions and Dependencies**: Prevents arbitrary downgrades of GitHub Actions or pinned dependencies without explicit requests.
3. **Hallucinated Dependency Versions**: Stops agents from bumping tools (like Node.js or `golangci-lint`) to non-existent future versions.
4. **Unhandled Errors in Go Code**: Enforces the project convention that all errors (including those from I/O operations like `fmt.Fprintln` or `Close()`) must be explicitly checked.
5. **Improper CLI Output Formatting**: Clarifies the boundary between `slog` (for machine-readable application logs) and `stderr` (for human-facing CLI instructions/prompts).

### Assumptions
- The PR rejections were caused by these specific patterns.
- `.jules/CONSISTENTLY_IGNORED.md` is the designated location for these negative memory rules.

### Alternatives Not Chosen
- Integrating these rules directly into `AGENTS.md`. Kept them in `.jules/` as requested to serve specifically as negative memory/pivot instructions for agents.

### How To Pivot
To change or remove a specific rule, edit `.jules/CONSISTENTLY_IGNORED.md` and adjust the markdown entry.

### Next Knobs
- The exact formatting of the markdown rule entries.
- Adding additional rules from older PRs not included in this batch.

---
*PR created automatically by Jules for task [5795221959996235506](https://jules.google.com/task/5795221959996235506) started by @lucasew*