### PR TITLE
🧹 Janitor: Fix minor linting and formatting issues

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-18: Omit type inferences, replace deprecated types, use switch on enums instead of chained ifs, prefer math expansion over function calls, and expand shell vars safely in trap and echo string literals.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -67,7 +67,7 @@ func Register[T any](provider DriverProvider[T]) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	var t reflect.Type = reflect.TypeFor[T]()
+	t := reflect.TypeFor[T]()
 	if t.Kind() != reflect.Interface {
 		panic(fmt.Errorf("driver %s is not an interface", t.String()))
 	}
@@ -104,7 +104,7 @@ func getInterfaceName(t reflect.Type) string {
 
 func Get[T any](ctx context.Context) (T, error) {
 	mu.RLock()
-	var t reflect.Type = reflect.TypeFor[T]()
+	t := reflect.TypeFor[T]()
 	if t.Kind() != reflect.Interface {
 		mu.RUnlock()
 		var zero T

--- a/pkg/modfile/sourceprovider/github/tarball.go
+++ b/pkg/modfile/sourceprovider/github/tarball.go
@@ -155,7 +155,7 @@ func extractTarEntry(tr *tar.Reader, hdr *tar.Header, target string) error {
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		return os.MkdirAll(target, 0755)
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg:
 		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 			return err
 		}

--- a/pkg/palette/genetic/fitness.go
+++ b/pkg/palette/genetic/fitness.go
@@ -119,10 +119,11 @@ func calculateImageSimilarity(paletteColors []api.LAB, imageColors []api.LAB) fl
 func calculateLightnessError(colors []api.LAB, polarity api.Polarity) float64 {
 	var targetLightnesses []float64
 
-	if polarity == api.PolarityDark {
+	switch polarity {
+	case api.PolarityDark:
 		// Dark theme: background dark, foreground light
 		targetLightnesses = []float64{10, 30, 45, 65, 75, 90, 95, 95}
-	} else if polarity == api.PolarityLight {
+	case api.PolarityLight:
 		// Light theme: background light, foreground dark
 		targetLightnesses = []float64{90, 70, 55, 35, 25, 10, 5, 5}
 	}
@@ -222,8 +223,8 @@ func calculateHueDiversity(colors []api.LAB) float64 {
 
 	var aVariance, bVariance float64
 	for _, c := range colors {
-		aVariance += math.Pow(c.A-aMean, 2)
-		bVariance += math.Pow(c.B-bMean, 2)
+		aVariance += (c.A - aMean) * (c.A - aMean)
+		bVariance += (c.B - bMean) * (c.B - bMean)
 	}
 	aVariance /= float64(len(colors))
 	bVariance /= float64(len(colors))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,7 +58,7 @@ info "Latest version: ${VERSION}"
 
 # Download binary
 TMP=$(mktemp -d)
-trap "rm -rf ${TMP}" EXIT
+trap 'rm -rf "${TMP}"' EXIT
 
 BINARY_NAME="workspaced-${GOOS}-${GOARCH}"
 URL="https://github.com/lucasew/workspaced/releases/download/${VERSION}/${BINARY_NAME}"
@@ -82,11 +82,11 @@ info "Installation successful!"
 
 # Check if ~/.local/bin is in PATH
 if [[ ":${PATH}:" != *":${HOME}/.local/bin:"* ]]; then
-	warn "~/.local/bin is not in your PATH"
+	warn "${HOME}/.local/bin is not in your PATH"
 	echo ""
 	echo "Add the following to your shell configuration (~/.bashrc, ~/.zshrc, etc):"
 	echo ""
-	echo '    export PATH="$HOME/.local/bin:$PATH"'
+	echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
 	echo ""
 fi
 


### PR DESCRIPTION
### What Changed
- `pkg/driver/driver.go`: Removed redundant `reflect.Type` variable types in assignments (`ST1023`).
- `pkg/modfile/sourceprovider/github/tarball.go`: Removed deprecated `tar.TypeRegA` from the tar header switch case (`SA1019`).
- `pkg/palette/genetic/fitness.go`: Replaced an `if/else if` chain matching against `polarity` with a standard `switch` statement (`QF1003`). Also replaced `math.Pow` calls with standard inline multiplications for better performance (`QF1005`).
- `scripts/install.sh`: Corrected variable expansion to avoid issues within single quotes and resolved shellcheck errors regarding trap and variable paths.
- `.jules/janitor.md`: Logged a new reusable insight tracking this pattern for future tasks.

### Why This Helps
These cleanups resolve several low-hanging fruit warnings found via the golangci-lint and shellcheck suites. The code becomes cleaner, faster (in the case of replacing `math.Pow`), easier to read (with `switch`), and more durable for legacy tooling. 

### Before/After
- **Before:** Linter errors across `driver.go`, `tarball.go`, `fitness.go`, and `install.sh`.
- **After:** Zero linter errors for these files.

### Verification
- `mise run lint`: Confirmed 0 warnings related to these modified blocks.
- `go test ./...`: Passed (no regressions introduced by these simplifications).

### Assumptions
- Removing `tar.TypeRegA` is safe since GitHub tarballs emit modern files.
- Modifying `scripts/install.sh` string literals preserves identical bash expansion behavior due to correctly nesting double and single quotes.

### Alternatives Not Chosen
- I could have suppressed the warnings instead of fixing them, but the project guidelines strictly require fixing root causes over using suppression directives.

### How To Pivot
- If the `tar.TypeRegA` removal is determined to be too risky for compatibility, you can revert `pkg/modfile/sourceprovider/github/tarball.go` using `git checkout HEAD^ pkg/modfile/sourceprovider/github/tarball.go`.

### Next Knobs
- `pkg/modfile/sourceprovider/github/tarball.go`: You can re-add `tar.TypeRegA` if compatibility issues arise.
- `scripts/install.sh`: The logic for `PATH` injection can be tweaked if the double-quote escaping strategy is not visually ideal.

---
*PR created automatically by Jules for task [2649370518499568092](https://jules.google.com/task/2649370518499568092) started by @lucasew*