### PR TITLE
🧹 Janitor: Fix minor linting and formatting issues

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,1 +1,1 @@
-- 2024-05-18: Unhandled return errors (like Close, Flush) must be explicitly checked, funneled through the centralized error reporting function, or explicitly ignored using an underscore.
+- 2024-05-18: Unhandled return errors (like Close, Flush) must be explicitly checked and funneled through the centralized error reporting function.

--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2024-05-18: Unhandled return errors (like Close, Flush) must be explicitly checked, funneled through the centralized error reporting function, or explicitly ignored using an underscore.

--- a/cmd/workspaced/codebase/lint.go
+++ b/cmd/workspaced/codebase/lint.go
@@ -72,7 +72,9 @@ func saveSarifToCI(report *sarif.Report) {
 			if err := encoder.Encode(report); err != nil {
 				slog.Warn("failed to write SARIF report", "sarif_path", sarifPath, "error", err)
 			}
-			file.Close()
+			if err := file.Close(); err != nil {
+				slog.Warn("failed to close SARIF report file", "sarif_path", sarifPath, "error", err)
+			}
 		}
 	}
 }
@@ -92,7 +94,7 @@ func printReport(report *sarif.Report, format string) error {
 
 func printTable(report *sarif.Report) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "TOOL\tLEVEL\tFILE:LINE\tMESSAGE")
+	_, _ = fmt.Fprintln(w, "TOOL\tLEVEL\tFILE:LINE\tMESSAGE")
 
 	for _, run := range report.Runs {
 		toolName := run.Tool.Driver.Name
@@ -134,9 +136,8 @@ func printTable(report *sarif.Report) error {
 				level = *res.Level
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", toolName, level, fileLine, msg)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", toolName, level, fileLine, msg)
 		}
 	}
-	w.Flush()
-	return nil
+	return w.Flush()
 }

--- a/cmd/workspaced/driver/doctor/root.go
+++ b/cmd/workspaced/driver/doctor/root.go
@@ -21,7 +21,7 @@ func GetCommand() *cobra.Command {
 			report := driver.Doctor(cmd.Context())
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "TYPE\tID\tDRIVER\tWEIGHT\tSTATUS\tMESSAGE")
+			_, _ = fmt.Fprintln(w, "TYPE\tID\tDRIVER\tWEIGHT\tSTATUS\tMESSAGE")
 
 			for _, iface := range report {
 				// Use full interface name if verbose, otherwise friendly name
@@ -67,10 +67,10 @@ func GetCommand() *cobra.Command {
 						driverName = fmt.Sprintf("%s (%s)", d.Name, d.ID)
 					}
 
-					fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n", typeName, providerID, driverName, d.Weight, status, msg)
+					_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n", typeName, providerID, driverName, d.Weight, status, msg)
 				}
 			}
-			w.Flush()
+			_ = w.Flush()
 		},
 	}
 	c.Flags().BoolP("verbose", "v", false, "Show full interface and driver names")

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -67,7 +67,7 @@ func Register[T any](provider DriverProvider[T]) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	var t reflect.Type = reflect.TypeFor[T]()
+	t := reflect.TypeFor[T]()
 	if t.Kind() != reflect.Interface {
 		panic(fmt.Errorf("driver %s is not an interface", t.String()))
 	}
@@ -104,7 +104,7 @@ func getInterfaceName(t reflect.Type) string {
 
 func Get[T any](ctx context.Context) (T, error) {
 	mu.RLock()
-	var t reflect.Type = reflect.TypeFor[T]()
+	t := reflect.TypeFor[T]()
 	if t.Kind() != reflect.Interface {
 		mu.RUnlock()
 		var zero T

--- a/pkg/modfile/sourceprovider/github/tarball.go
+++ b/pkg/modfile/sourceprovider/github/tarball.go
@@ -155,7 +155,7 @@ func extractTarEntry(tr *tar.Reader, hdr *tar.Header, target string) error {
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		return os.MkdirAll(target, 0755)
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg:
 		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 			return err
 		}

--- a/pkg/palette/genetic/fitness.go
+++ b/pkg/palette/genetic/fitness.go
@@ -119,10 +119,11 @@ func calculateImageSimilarity(paletteColors []api.LAB, imageColors []api.LAB) fl
 func calculateLightnessError(colors []api.LAB, polarity api.Polarity) float64 {
 	var targetLightnesses []float64
 
-	if polarity == api.PolarityDark {
+	switch polarity {
+	case api.PolarityDark:
 		// Dark theme: background dark, foreground light
 		targetLightnesses = []float64{10, 30, 45, 65, 75, 90, 95, 95}
-	} else if polarity == api.PolarityLight {
+	case api.PolarityLight:
 		// Light theme: background light, foreground dark
 		targetLightnesses = []float64{90, 70, 55, 35, 25, 10, 5, 5}
 	}
@@ -222,8 +223,8 @@ func calculateHueDiversity(colors []api.LAB) float64 {
 
 	var aVariance, bVariance float64
 	for _, c := range colors {
-		aVariance += math.Pow(c.A-aMean, 2)
-		bVariance += math.Pow(c.B-bMean, 2)
+		aVariance += (c.A - aMean) * (c.A - aMean)
+		bVariance += (c.B - bMean) * (c.B - bMean)
 	}
 	aVariance /= float64(len(colors))
 	bVariance /= float64(len(colors))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,7 +58,7 @@ info "Latest version: ${VERSION}"
 
 # Download binary
 TMP=$(mktemp -d)
-trap "rm -rf ${TMP}" EXIT
+trap 'rm -rf "${TMP}"' EXIT
 
 BINARY_NAME="workspaced-${GOOS}-${GOARCH}"
 URL="https://github.com/lucasew/workspaced/releases/download/${VERSION}/${BINARY_NAME}"
@@ -82,7 +82,7 @@ info "Installation successful!"
 
 # Check if ~/.local/bin is in PATH
 if [[ ":${PATH}:" != *":${HOME}/.local/bin:"* ]]; then
-	warn "~/.local/bin is not in your PATH"
+	warn "${HOME}/.local/bin is not in your PATH"
 	echo ""
 	echo "Add the following to your shell configuration (~/.bashrc, ~/.zshrc, etc):"
 	echo ""


### PR DESCRIPTION
This PR addresses a number of minor code quality and linting issues identified by `mise run lint` (golangci-lint and shellcheck).

### Assumptions
- Modifying string formatting logic in the installation scripts explicitly addresses the shellcheck findings without altering its functionality.
- Deprecated `tar.TypeRegA` behaves identically to `tar.TypeReg` in newer versions of Go, so its removal is a safe refactor.
- Adding a journal entry to `.jules/janitor.md` explicitly capturing the unhandled error checking pattern satisfies the agent objective of documenting code quality insights.

### Alternatives Not Chosen
- Automating unhandled error replacements with a custom script. While doing so could fix 100% of the occurrences, manually adjusting the 4 most prominent ones explicitly allows avoiding scope creep.
- Completely wrapping the print stream in `doctor` with error handling instead of ignoring it with an underscore. Decided against it because pure CLI printing functions explicitly logging simple text streams usually have negligible failure modes compared to IO streams.

### How To Pivot
If any of the `_ = fmt.Fprintf` statements are deemed to require rigorous handling, you can easily change `_ = fmt.Fprintf` back into an `err := ...` block. 

### Next Knobs
- The `.jules/janitor.md` file can be updated to specify exactly which types of errors require tracking via `logging.ReportError` versus which ones are allowed to be ignored.
- The remaining instances of unhandled error lint warnings can be fixed in subsequent targeted PRs.

---
*PR created automatically by Jules for task [14921224896117762948](https://jules.google.com/task/14921224896117762948) started by @lucasew*