### PR TITLE
feat: add v4l-ffmpeg camera driver

### DIFF
--- a/cmd/workspaced/driver/camera/capture.go
+++ b/cmd/workspaced/driver/camera/capture.go
@@ -2,9 +2,11 @@ package camera
 
 import (
 	"fmt"
+	"image"
 	"image/png"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,10 +47,11 @@ func capture(cmd *cobra.Command, id, outPath string) error {
 		return err
 	}
 
-	img, err := cam.Capture(cmd.Context())
+	usedCam, img, err := captureFromCamera(cmd, cams, cam, id)
 	if err != nil {
 		return err
 	}
+	cam = usedCam
 
 	if outPath == "-" {
 		return png.Encode(cmd.OutOrStdout(), img)
@@ -91,6 +94,39 @@ func selectCamera(cams []cameraapi.Camera, id string) (cameraapi.Camera, error) 
 		}
 	}
 	return nil, fmt.Errorf("camera %q not found", id)
+}
+
+func captureFromCamera(cmd *cobra.Command, cams []cameraapi.Camera, preferred cameraapi.Camera, id string) (cameraapi.Camera, image.Image, error) {
+	if id != "" {
+		img, err := preferred.Capture(cmd.Context())
+		return preferred, img, err
+	}
+
+	ordered := append([]cameraapi.Camera(nil), cams...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return cameraPriority(ordered[i]) < cameraPriority(ordered[j])
+	})
+
+	var errs []string
+	for _, cam := range ordered {
+		img, err := cam.Capture(cmd.Context())
+		if err == nil {
+			return cam, img, nil
+		}
+		errs = append(errs, fmt.Sprintf("%s: %v", cam.ID(), err))
+	}
+	if len(errs) == 0 {
+		return nil, nil, fmt.Errorf("no cameras found")
+	}
+	return nil, nil, fmt.Errorf("failed to capture from any camera: %s", strings.Join(errs, "; "))
+}
+
+func cameraPriority(cam cameraapi.Camera) int {
+	name := strings.ToLower(cam.Name())
+	if strings.Contains(name, "dummy") || strings.Contains(name, "virtual") {
+		return 1
+	}
+	return 0
 }
 
 func matchesCamera(cam cameraapi.Camera, id string) bool {

--- a/cmd/workspaced/driver/camera/capture.go
+++ b/cmd/workspaced/driver/camera/capture.go
@@ -5,83 +5,144 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"workspaced/pkg/driver"
-	"workspaced/pkg/driver/camera"
+	cameraapi "workspaced/pkg/driver/camera"
 
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	var output string
-	var cameraID string
-
 	Registry.Register(func(parent *cobra.Command) {
 		cmd := &cobra.Command{
 			Use:   "capture",
-			Short: "Capture a still frame from camera",
-			RunE: func(c *cobra.Command, args []string) error {
-				d, err := driver.Get[camera.Driver](c.Context())
-				if err != nil {
-					return err
-				}
-
-				cams, err := d.List(c.Context())
-				if err != nil {
-					return err
-				}
-				if len(cams) == 0 {
-					return fmt.Errorf("no camera devices found")
-				}
-
-				selected := cams[0]
-				if cameraID != "" {
-					found := false
-					for _, cam := range cams {
-						if cam.ID() == cameraID {
-							selected = cam
-							found = true
-							break
-						}
-					}
-					if !found {
-						return fmt.Errorf("camera %q not found", cameraID)
-					}
-				}
-
-				img, err := selected.Capture(c.Context())
-				if err != nil {
-					return err
-				}
-
-				target := output
-				if target == "" {
-					timestamp := time.Now().Format("2006-01-02_15-04-05")
-					target = fmt.Sprintf("Camera_%s_%s.png", selected.ID(), timestamp)
-				}
-
-				if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-					return fmt.Errorf("failed to create output dir: %w", err)
-				}
-
-				f, err := os.Create(target)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer f.Close()
-
-				if err := png.Encode(f, img); err != nil {
-					return fmt.Errorf("failed to encode image: %w", err)
-				}
-
-				c.Println(target)
-				return nil
+			Short: "Capture a still frame",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				id, _ := cmd.Flags().GetString("id")
+				outPath, _ := cmd.Flags().GetString("output")
+				return capture(cmd, id, outPath)
 			},
 		}
-		cmd.Flags().StringVarP(&output, "output", "o", "", "Output image path (png)")
-		cmd.Flags().StringVar(&cameraID, "id", "", "Camera device id")
-
+		cmd.Flags().StringP("id", "i", "", "camera ID or name (defaults to the first camera)")
+		cmd.Flags().StringP("output", "o", "", "output path (use - for stdout; defaults to cache directory)")
 		parent.AddCommand(cmd)
 	})
+}
+
+func capture(cmd *cobra.Command, id, outPath string) error {
+	drv, err := driver.Get[cameraapi.Driver](cmd.Context())
+	if err != nil {
+		return err
+	}
+	cams, err := drv.List(cmd.Context())
+	if err != nil {
+		return err
+	}
+	cam, err := selectCamera(cams, id)
+	if err != nil {
+		return err
+	}
+
+	img, err := cam.Capture(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if outPath == "-" {
+		return png.Encode(cmd.OutOrStdout(), img)
+	}
+
+	if outPath == "" {
+		outPath, err = defaultCameraPath(cam)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+	if err := png.Encode(out, img); err != nil {
+		return err
+	}
+	cmd.Println(outPath)
+	return nil
+}
+
+func selectCamera(cams []cameraapi.Camera, id string) (cameraapi.Camera, error) {
+	if len(cams) == 0 {
+		return nil, fmt.Errorf("no cameras found")
+	}
+	if id == "" {
+		return cams[0], nil
+	}
+	for _, cam := range cams {
+		if matchesCamera(cam, id) {
+			return cam, nil
+		}
+	}
+	return nil, fmt.Errorf("camera %q not found", id)
+}
+
+func matchesCamera(cam cameraapi.Camera, id string) bool {
+	if cam.ID() == id || filepath.Base(cam.ID()) == id {
+		return true
+	}
+	if cam.Name() == id {
+		return true
+	}
+	return sanitizeComponent(cam.Name()) == sanitizeComponent(id)
+}
+
+func defaultCameraPath(cam cameraapi.Camera) (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return "", err
+		}
+		cacheDir = filepath.Join(home, ".cache")
+	}
+	cameraDir := filepath.Join(cacheDir, "workspaced", "camera")
+	if err := os.MkdirAll(cameraDir, 0755); err != nil {
+		return "", err
+	}
+	stamp := time.Now().Format("2006-01-02_15-04-05")
+	name := sanitizeComponent(cam.Name())
+	if name == "" {
+		name = sanitizeComponent(filepath.Base(cam.ID()))
+	}
+	if name == "" {
+		name = "camera"
+	}
+	return filepath.Join(cameraDir, fmt.Sprintf("%s_%s.png", stamp, name)), nil
+}
+
+func sanitizeComponent(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return strings.Trim(b.String(), "_")
 }

--- a/cmd/workspaced/driver/camera/list.go
+++ b/cmd/workspaced/driver/camera/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"workspaced/pkg/driver"
-	"workspaced/pkg/driver/camera"
+	cameraapi "workspaced/pkg/driver/camera"
 
 	"github.com/spf13/cobra"
 )
@@ -13,22 +13,22 @@ func init() {
 	Registry.Register(func(parent *cobra.Command) {
 		parent.AddCommand(&cobra.Command{
 			Use:   "list",
-			Short: "List available cameras",
-			RunE: func(c *cobra.Command, args []string) error {
-				d, err := driver.Get[camera.Driver](c.Context())
+			Short: "List cameras",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				drv, err := driver.Get[cameraapi.Driver](cmd.Context())
 				if err != nil {
 					return err
 				}
-
-				cams, err := d.List(c.Context())
+				cams, err := drv.List(cmd.Context())
 				if err != nil {
 					return err
 				}
-
+				if len(cams) == 0 {
+					return fmt.Errorf("no cameras found")
+				}
 				for _, cam := range cams {
-					c.Println(fmt.Sprintf("%s\t%s", cam.ID(), cam.Name()))
+					cmd.Printf("%s\t%s\n", cam.ID(), cam.Name())
 				}
-
 				return nil
 			},
 		})

--- a/cmd/workspaced/driver/camera/root.go
+++ b/cmd/workspaced/driver/camera/root.go
@@ -1,8 +1,9 @@
 package camera
 
 import (
-	"github.com/spf13/cobra"
 	"workspaced/pkg/registry"
+
+	"github.com/spf13/cobra"
 )
 
 var Registry registry.CommandRegistry
@@ -10,7 +11,7 @@ var Registry registry.CommandRegistry
 func GetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "camera",
-		Short: "Camera management",
+		Short: "Camera capture management",
 	}
 	return Registry.FillCommands(cmd)
 }

--- a/pkg/driver/camera/linux/driver.go
+++ b/pkg/driver/camera/linux/driver.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"image"
 	_ "image/png"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -104,9 +103,14 @@ func (c *cameraDevice) Capture(ctx context.Context) (image.Image, error) {
 		"-")
 
 	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = io.Discard
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("ffmpeg capture from %s failed: %w: %s", c.device, err, msg)
+		}
 		return nil, fmt.Errorf("ffmpeg capture from %s failed: %w", c.device, err)
 	}
 

--- a/pkg/driver/camera/linux/driver.go
+++ b/pkg/driver/camera/linux/driver.go
@@ -1,0 +1,144 @@
+package linux
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	_ "image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"workspaced/pkg/driver"
+	cameraapi "workspaced/pkg/driver/camera"
+	execdriver "workspaced/pkg/driver/exec"
+)
+
+func init() {
+	driver.Register[cameraapi.Driver](&Provider{})
+}
+
+type Provider struct{}
+
+func (p *Provider) ID() string   { return "v4l-ffmpeg" }
+func (p *Provider) Name() string { return "V4L2 + ffmpeg" }
+
+func (p *Provider) CheckCompatibility(ctx context.Context) error {
+	if runtime.GOOS != "linux" {
+		return fmt.Errorf("%w: linux is required", driver.ErrIncompatible)
+	}
+	if !execdriver.IsBinaryAvailable(ctx, "ffmpeg") {
+		return fmt.Errorf("%w: ffmpeg is required", driver.ErrIncompatible)
+	}
+	return nil
+}
+
+func (p *Provider) New(ctx context.Context) (cameraapi.Driver, error) {
+	return &Driver{}, nil
+}
+
+type Driver struct{}
+
+type cameraDevice struct {
+	device string
+	id     string
+	name   string
+}
+
+func (d *Driver) List(ctx context.Context) ([]cameraapi.Camera, error) {
+	devices, err := filepath.Glob("/dev/video*")
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(devices, func(i, j int) bool {
+		ii := videoIndex(devices[i])
+		ij := videoIndex(devices[j])
+		if ii != ij {
+			return ii < ij
+		}
+		return devices[i] < devices[j]
+	})
+
+	cams := make([]cameraapi.Camera, 0, len(devices))
+	for _, dev := range devices {
+		info, err := os.Stat(dev)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeDevice == 0 {
+			continue
+		}
+		cams = append(cams, &cameraDevice{
+			device: dev,
+			id:     dev,
+			name:   cameraName(dev),
+		})
+	}
+	return cams, nil
+}
+
+func (c *cameraDevice) ID() string { return c.id }
+
+func (c *cameraDevice) Name() string { return c.name }
+
+func (c *cameraDevice) Capture(ctx context.Context) (image.Image, error) {
+	if !execdriver.IsBinaryAvailable(ctx, "ffmpeg") {
+		return nil, fmt.Errorf("%w: ffmpeg not found", driver.ErrIncompatible)
+	}
+
+	cmd := execdriver.MustRun(ctx, "ffmpeg",
+		"-hide_banner",
+		"-loglevel", "error",
+		"-nostdin",
+		"-f", "video4linux2",
+		"-i", c.device,
+		"-frames:v", "1",
+		"-f", "image2pipe",
+		"-vcodec", "png",
+		"-")
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg capture from %s failed: %w", c.device, err)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode camera frame from %s: %w", c.device, err)
+	}
+	return img, nil
+}
+
+func cameraName(device string) string {
+	base := filepath.Base(device)
+	sysfs := filepath.Join("/sys/class/video4linux", base, "name")
+	data, err := os.ReadFile(sysfs)
+	if err != nil {
+		return base
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "" {
+		return base
+	}
+	return name
+}
+
+func videoIndex(device string) int {
+	base := filepath.Base(device)
+	if !strings.HasPrefix(base, "video") {
+		return int(^uint(0) >> 1)
+	}
+	idx, err := strconv.Atoi(strings.TrimPrefix(base, "video"))
+	if err != nil {
+		return int(^uint(0) >> 1)
+	}
+	return idx
+}

--- a/pkg/driver/prelude/prelude.go
+++ b/pkg/driver/prelude/prelude.go
@@ -4,6 +4,7 @@ import (
 	_ "workspaced/pkg/driver/audio/pulse"
 	_ "workspaced/pkg/driver/battery/linux"
 	_ "workspaced/pkg/driver/brightness/brightnessctl"
+	_ "workspaced/pkg/driver/camera/linux"
 	_ "workspaced/pkg/driver/clipboard/termux"
 	_ "workspaced/pkg/driver/clipboard/wlcopy"
 	_ "workspaced/pkg/driver/clipboard/xclip"


### PR DESCRIPTION
## Summary
- Adds a new `pkg/driver/camera` interface package
- Implements a Linux V4L2 + ffmpeg backend under `pkg/driver/camera/linux`
- Adds `workspaced driver camera list` and `workspaced driver camera capture` commands
- Capture uses the first camera by default and supports `--id` and `--output`

## Notes
- The provider ID is `v4l-ffmpeg`
- Default capture output goes to the user cache directory (`~/.cache/workspaced/camera`)
- `--output -` streams PNG bytes to stdout

## Verification
- `mise exec -- go test ./cmd/workspaced/driver/camera ./pkg/driver/camera/... ./pkg/driver/prelude`
