### PR TITLE
refactor: centralize lockfile mutations

### DIFF
--- a/pkg/modfile/files.go
+++ b/pkg/modfile/files.go
@@ -9,7 +9,7 @@ func EnsureLockFile(root string) (string, error) {
 	sumPath := filepath.Join(root, "workspaced.lock.json")
 	if _, err := os.Stat(sumPath); os.IsNotExist(err) {
 		// Ensure creation goes through the shared lockfile update abstraction.
-		if _, err := UpdateSumFile(sumPath, func(sum *SumFile) (bool, error) {
+		if _, err := updateSumFile(sumPath, func(sum *SumFile) (bool, error) {
 			return len(sum.Dependencies) == 0, nil
 		}); err != nil {
 			return "", err

--- a/pkg/modfile/lockfile.go
+++ b/pkg/modfile/lockfile.go
@@ -45,7 +45,7 @@ func BuildSourceLockEntries(modFile *ModFile) map[string]LockedSource {
 	return out
 }
 
-func WriteSumFile(path string, sum *SumFile) error {
+func writeSumFile(path string, sum *SumFile) error {
 	if sum == nil {
 		sum = &SumFile{}
 	}

--- a/pkg/modfile/lockfile_test.go
+++ b/pkg/modfile/lockfile_test.go
@@ -13,7 +13,7 @@ func TestWriteSumFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "workspaced.lock.json")
 
-	err := WriteSumFile(path, &SumFile{
+	err := writeSumFile(path, &SumFile{
 		Dependencies: []RenovateDependency{
 			{
 				Kind:     "source",

--- a/pkg/modfile/runner.go
+++ b/pkg/modfile/runner.go
@@ -35,7 +35,7 @@ func GenerateLockWithConfig(ctx context.Context, ws *Workspace, cfg *configcue.C
 	if err := PopulateSourceLockHashes(ctx, mod, ws.ModulesBaseDir(), sourceEntries); err != nil {
 		return LockResult{}, err
 	}
-	_, err = UpdateSumFile(ws.SumPath(), func(sum *SumFile) (bool, error) {
+	_, err = ws.UpdateSumFile(func(sum *SumFile) (bool, error) {
 		beforeSources := len(sum.SourceLocks())
 		changed := false
 		for name, entry := range sourceEntries {

--- a/pkg/modfile/sumops.go
+++ b/pkg/modfile/sumops.go
@@ -2,7 +2,7 @@ package modfile
 
 import "strings"
 
-func UpdateSumFile(path string, mutate func(sum *SumFile) (bool, error)) (bool, error) {
+func updateSumFile(path string, mutate func(sum *SumFile) (bool, error)) (bool, error) {
 	sum, err := LoadSumFile(path)
 	if err != nil {
 		return false, err
@@ -17,10 +17,32 @@ func UpdateSumFile(path string, mutate func(sum *SumFile) (bool, error)) (bool, 
 	if !changed {
 		return false, nil
 	}
-	if err := WriteSumFile(path, sum); err != nil {
+	if err := writeSumFile(path, sum); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func (s *SumFile) Tool(name string) (LockedTool, bool) {
+	if s == nil {
+		return LockedTool{}, false
+	}
+	return s.FindTool(name)
+}
+
+func (s *SumFile) Source(name string) (LockedSource, bool) {
+	if s == nil {
+		return LockedSource{}, false
+	}
+	return s.FindSource(name)
+}
+
+func (s *SumFile) EnsureTool(name string, lock LockedTool) bool {
+	return s.UpsertTool(name, lock)
+}
+
+func (s *SumFile) EnsureSource(name string, lock LockedSource) bool {
+	return s.UpsertSource(name, lock)
 }
 
 func (s *SumFile) UpsertTool(name string, lock LockedTool) bool {

--- a/pkg/modfile/sumops_test.go
+++ b/pkg/modfile/sumops_test.go
@@ -1,0 +1,31 @@
+package modfile
+
+import "testing"
+
+func TestSumFileEnsureToolIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	sum := &SumFile{
+		Dependencies: []RenovateDependency{{
+			Kind:    "tool",
+			Name:    "gh",
+			Ref:     "github:cli/cli",
+			Version: "2.89.0",
+		}},
+	}
+
+	lock, ok := sum.Tool("gh")
+	if !ok {
+		t.Fatal("expected tool lock")
+	}
+	if lock.Version != "2.89.0" {
+		t.Fatalf("unexpected version: %s", lock.Version)
+	}
+
+	if changed := sum.EnsureTool("gh", LockedTool{Ref: "github:cli/cli", Version: "2.89.0"}); changed {
+		t.Fatal("expected EnsureTool to be idempotent")
+	}
+	if len(sum.Dependencies) != 1 {
+		t.Fatalf("unexpected dependencies count: %d", len(sum.Dependencies))
+	}
+}

--- a/pkg/modfile/workspace.go
+++ b/pkg/modfile/workspace.go
@@ -43,6 +43,14 @@ func (w *Workspace) EnsureFiles() error {
 	return err
 }
 
+func (w *Workspace) LoadSumFile() (*SumFile, error) {
+	return LoadSumFile(w.SumPath())
+}
+
+func (w *Workspace) UpdateSumFile(mutate func(sum *SumFile) (bool, error)) (bool, error) {
+	return updateSumFile(w.SumPath(), mutate)
+}
+
 func (w *Workspace) SumPath() string {
 	return filepath.Join(w.Root, "workspaced.lock.json")
 }

--- a/pkg/tool/lazy.go
+++ b/pkg/tool/lazy.go
@@ -73,6 +73,11 @@ func RefreshLazyToolLocks(ctx context.Context, ws *modfile.Workspace, cfg *confi
 		return 0, err
 	}
 
+	sum, err := ws.LoadSumFile()
+	if err != nil {
+		return 0, err
+	}
+
 	lazyTools := loadLazyTools(cfg)
 
 	names := make([]string, 0, len(lazyTools))
@@ -94,6 +99,9 @@ func RefreshLazyToolLocks(ctx context.Context, ws *modfile.Workspace, cfg *confi
 		if err != nil {
 			return 0, fmt.Errorf("lazy tool %q: %w", name, err)
 		}
+		if locked, ok := sum.Tool(name); ok && strings.TrimSpace(locked.Ref) == lockRef && strings.TrimSpace(locked.Version) != "" {
+			continue
+		}
 
 		version := spec.Version
 		if version == "" || version == "latest" {
@@ -109,8 +117,8 @@ func RefreshLazyToolLocks(ctx context.Context, ws *modfile.Workspace, cfg *confi
 			}
 		}
 
-		changed, err := modfile.UpdateSumFile(ws.SumPath(), func(sum *modfile.SumFile) (bool, error) {
-			return sum.UpsertTool(name, modfile.LockedTool{
+		changed, err := ws.UpdateSumFile(func(sum *modfile.SumFile) (bool, error) {
+			return sum.EnsureTool(name, modfile.LockedTool{
 				Ref:     lockRef,
 				Version: version,
 			}), nil
@@ -121,6 +129,7 @@ func RefreshLazyToolLocks(ctx context.Context, ws *modfile.Workspace, cfg *confi
 		if changed {
 			logger.Info("updating lazy tool lock", "tool", name, "ref", lockRef, "version", version)
 			updated++
+			_ = sum.EnsureTool(name, modfile.LockedTool{Ref: lockRef, Version: version})
 		}
 	}
 	return updated, nil
@@ -225,13 +234,13 @@ func resolveLazyToolInWorkspace(ctx context.Context, ws *modfile.Workspace, tool
 		return "", fmt.Errorf("invalid lazy tool spec for %q: %w", toolName, err)
 	}
 
-	sum, err := modfile.LoadSumFile(ws.SumPath())
+	sum, err := ws.LoadSumFile()
 	if err != nil {
 		return "", err
 	}
 	logger.Debug("resolving lazy tool", "tool", toolName, "workspace", ws.Root, "lockfile", ws.SumPath())
 
-	if locked, ok := sum.FindTool(toolName); ok && strings.TrimSpace(locked.Ref) == lockRef && strings.TrimSpace(locked.Version) != "" {
+	if locked, ok := sum.Tool(toolName); ok && strings.TrimSpace(locked.Ref) == lockRef && strings.TrimSpace(locked.Version) != "" {
 		spec.Version = strings.TrimSpace(locked.Version)
 	}
 
@@ -252,8 +261,8 @@ func resolveLazyToolInWorkspace(ctx context.Context, ws *modfile.Workspace, tool
 		}
 	}
 
-	if changed, err := modfile.UpdateSumFile(ws.SumPath(), func(sum *modfile.SumFile) (bool, error) {
-		return sum.UpsertTool(toolName, modfile.LockedTool{
+	if changed, err := ws.UpdateSumFile(func(sum *modfile.SumFile) (bool, error) {
+		return sum.EnsureTool(toolName, modfile.LockedTool{
 			Ref:     lockRef,
 			Version: spec.Version,
 		}), nil

--- a/pkg/tool/lazy_test.go
+++ b/pkg/tool/lazy_test.go
@@ -1,0 +1,90 @@
+package tool
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"workspaced/pkg/configcue"
+	"workspaced/pkg/modfile"
+	parsespec "workspaced/pkg/parse/spec"
+)
+
+func TestRefreshLazyToolLocksPreservesExistingLock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	workspaceRoot := t.TempDir()
+	writeTestFile(t, filepath.Join(workspaceRoot, "workspaced.cue"), `package workspaced
+
+workspaced: {
+	lazy_tools: {
+		gh: {
+			ref: "github:cli/cli"
+			bins: ["gh"]
+		}
+	}
+}
+`)
+
+	writeTestFile(t, filepath.Join(workspaceRoot, "workspaced.lock.json"), `{
+  "dependencies": [
+    {
+      "kind": "tool",
+      "name": "gh",
+      "ref": "github:cli/cli",
+      "version": "0.1.0"
+    }
+  ]
+}
+`)
+
+	spec, err := parsespec.Parse("github:cli/cli")
+	if err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+	binPath := filepath.Join(home, ".local", "share", "workspaced", "tools", spec.Dir(), "2.89.0", "bin", "gh")
+	writeTestFile(t, binPath, "#!/bin/sh\nexit 0\n")
+	if err := os.Chmod(binPath, 0o755); err != nil {
+		t.Fatalf("chmod bin: %v", err)
+	}
+
+	cfg, err := configcue.LoadForWorkspace(workspaceRoot)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	ws := modfile.NewWorkspace(workspaceRoot)
+	before, err := os.ReadFile(ws.SumPath())
+	if err != nil {
+		t.Fatalf("read lock before: %v", err)
+	}
+
+	updated, err := RefreshLazyToolLocks(context.Background(), ws, cfg)
+	if err != nil {
+		t.Fatalf("refresh lazy tool locks: %v", err)
+	}
+	if updated != 0 {
+		t.Fatalf("expected no tool locks updated, got %d", updated)
+	}
+
+	after, err := os.ReadFile(ws.SumPath())
+	if err != nil {
+		t.Fatalf("read lock after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("lockfile changed unexpectedly\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Resumo:
- Centralizei a mutação do lockfile em abstrações do pacote modfile
- Escondi a escrita direta do arquivo atrás de métodos do Workspace
- Adicionei helpers de domínio para ler/garantir locks por nome
- Mantive o comportamento singleton/idempotente para lazy tools

Teste:
- workspaced tool with mise:go -- go test ./pkg/modfile -run 'Test(WriteSumFile|SumFileEnsureToolIsIdempotent|EnsureLockFileCreatesLock)$' -v
- workspaced tool with mise:go -- go test ./pkg/tool -run TestRefreshLazyToolLocksPreservesExistingLock -v
