### PR TITLE
restructuration based on a prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 
 ## Driver System (minimal)
 
-Drivers implement `DriverProvider[T]`:
+Drivers implement `DriverFactory[T]`:
 - `ID()`, `Name()`, `CheckCompatibility()`, `New()`
 
 Selection is done by `driver.Get[T](ctx)` using weights from `workspaced.cue`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - Gives most of the benefits that Nix/NixOS has, but way faster
 
 ## Terminology
-- Driver: abstract interface to consume services of the operating system such as audio control, workspace management and cameras. Implementations are added through the registry pattern using the DriverProvider
+- Driver: abstract interface to consume services of the operating system such as audio control, workspace management and cameras. Implementations are added through the registry pattern using a DriverFactory
 - Linter: something that points issues in a codebase or a system
 - Formatter: something that restructures code to be in a specific structure without altering functionality
 - Tool: something that lists available versions and install a scoped program from a version. One tool version normally has assets and at least one executable binary
@@ -13,5 +13,5 @@
 - CUE: a JSON-like language that converges towards the most specific typing, allows validation together with data
 
 # TODO
-- [ ] Rename DriverProvider to something less provider
+- [x] Rename DriverProvider to DriverFactory
 - [ ] Dismember check into linter and formatter?

--- a/cmd/workspaced/daemon/daemon.go
+++ b/cmd/workspaced/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -32,8 +33,9 @@ import (
 )
 
 var (
-	shouldRestartDaemon bool
-	initialMtime        time.Time
+	shouldRestartDaemon    bool
+	initialMtime           time.Time
+	errNoRunImplementation = errors.New("command has no run implementation")
 )
 
 // initialMtime is populated early in the daemon command Run (before RunDaemon)
@@ -384,14 +386,13 @@ func handleRequest(ctx context.Context, req types.Request, outCh chan types.Stre
 	stdout := &StreamPacketWriter{Out: outCh, Type: "stdout"}
 	stderr := &StreamPacketWriter{Out: outCh, Type: "stderr"}
 
-	ctx = context.WithValue(ctx, types.LoggerKey, reqLogger)
-	ctx = context.WithValue(ctx, types.StdoutKey, stdout)
-	ctx = context.WithValue(ctx, types.StderrKey, stderr)
+	ctx = logging.ContextWithLogger(ctx, reqLogger)
+	ctx = executil.WithStdout(ctx, stdout)
+	ctx = executil.WithStderr(ctx, stderr)
 	env := append(req.Env, "WORKSPACED_DAEMON=1")
-	ctx = context.WithValue(ctx, types.EnvKey, env)
-	ctx = context.WithValue(ctx, types.DaemonModeKey, true)
+	ctx = executil.WithEnv(ctx, env)
 	// Inject DB into context so commands can use it
-	ctx = context.WithValue(ctx, types.DBKey, database)
+	ctx = db.WithDB(ctx, database)
 
 	output, err := ExecuteViaCobra(ctx, req, stdout, stderr)
 
@@ -449,7 +450,7 @@ func ExecuteViaCobra(ctx context.Context, req types.Request, stdout, stderr io.W
 	} else if targetCmd.Run != nil {
 		targetCmd.Run(targetCmd, argList)
 	} else {
-		err = fmt.Errorf("command has no run implementation")
+		err = errNoRunImplementation
 	}
 
 	return buf.String(), err

--- a/cmd/workspaced/demo/root.go
+++ b/cmd/workspaced/demo/root.go
@@ -2,6 +2,7 @@ package demo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+var errSimulated503 = errors.New("simulated 503 from registry (demo failure)")
 
 var Registry cmdregistry.CommandRegistry
 
@@ -135,7 +138,7 @@ func runTasksDemo(cmd *cobra.Command) error {
 		time.Sleep(140 * time.Millisecond)
 		logger.Info("POST", "path", "/artifacts")
 		time.Sleep(200 * time.Millisecond)
-		return fmt.Errorf("simulated 503 from registry (demo failure)")
+		return errSimulated503
 	}, "build")
 
 	return g.RunBubbleTea()

--- a/cmd/workspaced/driver/camera/capture.go
+++ b/cmd/workspaced/driver/camera/capture.go
@@ -1,6 +1,7 @@
 package camera
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"image/png"
@@ -14,6 +15,12 @@ import (
 	cameraapi "workspaced/pkg/driver/camera"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	errNoCamerasFound  = errors.New("no cameras found")
+	errCameraNotFound  = errors.New("camera not found")
+	errCaptureAllFailed = errors.New("failed to capture from any camera")
 )
 
 func init() {
@@ -83,7 +90,7 @@ func capture(cmd *cobra.Command, id, outPath string) error {
 
 func selectCamera(cams []cameraapi.Camera, id string) (cameraapi.Camera, error) {
 	if len(cams) == 0 {
-		return nil, fmt.Errorf("no cameras found")
+		return nil, errNoCamerasFound
 	}
 	if id == "" {
 		return cams[0], nil
@@ -93,7 +100,7 @@ func selectCamera(cams []cameraapi.Camera, id string) (cameraapi.Camera, error) 
 			return cam, nil
 		}
 	}
-	return nil, fmt.Errorf("camera %q not found", id)
+	return nil, fmt.Errorf("%w: %q", errCameraNotFound, id)
 }
 
 func captureFromCamera(cmd *cobra.Command, cams []cameraapi.Camera, preferred cameraapi.Camera, id string) (cameraapi.Camera, image.Image, error) {
@@ -116,9 +123,9 @@ func captureFromCamera(cmd *cobra.Command, cams []cameraapi.Camera, preferred ca
 		errs = append(errs, fmt.Sprintf("%s: %v", cam.ID(), err))
 	}
 	if len(errs) == 0 {
-		return nil, nil, fmt.Errorf("no cameras found")
+		return nil, nil, errNoCamerasFound
 	}
-	return nil, nil, fmt.Errorf("failed to capture from any camera: %s", strings.Join(errs, "; "))
+	return nil, nil, fmt.Errorf("%w: %s", errCaptureAllFailed, strings.Join(errs, "; "))
 }
 
 func cameraPriority(cam cameraapi.Camera) int {

--- a/cmd/workspaced/driver/camera/list.go
+++ b/cmd/workspaced/driver/camera/list.go
@@ -1,7 +1,7 @@
 package camera
 
 import (
-	"fmt"
+
 
 	"workspaced/pkg/driver"
 	cameraapi "workspaced/pkg/driver/camera"
@@ -24,7 +24,7 @@ func init() {
 					return err
 				}
 				if len(cams) == 0 {
-					return fmt.Errorf("no cameras found")
+					return errNoCamerasFound
 				}
 				for _, cam := range cams {
 					cmd.Printf("%s\t%s\n", cam.ID(), cam.Name())

--- a/cmd/workspaced/driver/doctor/root.go
+++ b/cmd/workspaced/driver/doctor/root.go
@@ -61,9 +61,9 @@ func GetCommand() *cobra.Command {
 
 					// Format ID based on verbose flag
 					providerID := d.ID
-					if verbose && d.ProviderType != nil {
-						// Show full provider struct path
-						providerID = getProviderTypeName(d.ProviderType)
+					if verbose && d.FactoryType != nil {
+						// Show full factory struct path
+						providerID = getFactoryTypeName(d.FactoryType)
 					}
 
 					// In verbose mode, show driver name with slug ID
@@ -121,8 +121,8 @@ func getFriendlyInterfaceName(fullPath string) string {
 	return strings.ToLower(pkg) + "." + strings.ToLower(typeName)
 }
 
-// getProviderTypeName returns the full path of a provider type
-func getProviderTypeName(t any) string {
+// getFactoryTypeName returns the full path of a factory type.
+func getFactoryTypeName(t any) string {
 	rt, ok := t.(reflect.Type)
 	if !ok {
 		return fmt.Sprintf("%v", t)

--- a/cmd/workspaced/driver/input/root.go
+++ b/cmd/workspaced/driver/input/root.go
@@ -1,12 +1,15 @@
 package input
 
 import (
+	"errors"
 	"fmt"
 	"workspaced/pkg/cmdregistry"
 	"workspaced/pkg/driver/dialog"
 
 	"github.com/spf13/cobra"
 )
+
+var errCancelled = errors.New("cancelled")
 
 var Registry cmdregistry.CommandRegistry
 
@@ -48,7 +51,7 @@ func GetCommand() *cobra.Command {
 				return err
 			}
 			if !ok {
-				return fmt.Errorf("cancelled")
+				return errCancelled
 			}
 			return nil
 		},

--- a/cmd/workspaced/home/apply/root.go
+++ b/cmd/workspaced/home/apply/root.go
@@ -57,13 +57,13 @@ func GetCommand() *cobra.Command {
 
 				logger := logging.GetLogger(ctx)
 
-				// Carregar configuração
+				// Load configuration
 				cfg, err := configcue.LoadHome(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to load config: %w", err)
 				}
 
-				// Obter dotfiles root
+				// Get dotfiles root
 				dotfilesRoot, err := env.GetDotfilesRoot(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get dotfiles root: %w", err)
@@ -80,17 +80,17 @@ func GetCommand() *cobra.Command {
 					return fmt.Errorf("failed to get home directory: %w", err)
 				}
 
-				// Criar template engine compartilhada
+				// Create shared template engine
 				engine := template.NewEngine(ctx)
 
-				// Configurar pipeline de plugins
+				// Configure plugin pipeline
 				configDir := filepath.Join(dotfilesRoot, "config")
 				pipeline := source.NewPipeline()
 
 				// 1. Provider dconf (legacy)
 				pipeline.AddPlugin(source.NewProviderPlugin(&apply.DconfProvider{}, 50))
 
-				// 2. Scanner - descobre arquivos em config/
+				// 2. Scanner - discovers files in config/
 				if _, err := os.Stat(configDir); err == nil {
 					scanner, err := source.NewScannerPlugin(source.ScannerConfig{
 						Name:       "legacy-config",
@@ -110,13 +110,13 @@ func GetCommand() *cobra.Command {
 					pipeline.AddPlugin(source.NewModuleScannerPlugin(modulesDir, cfg, 100))
 				}
 
-				// 3. TemplateExpander - renderiza .tmpl (inclui multi-file)
+				// 3. TemplateExpander - renders .tmpl (includes multi-file)
 				pipeline.AddPlugin(source.NewTemplateExpanderPlugin(engine, cfg))
 
-				// 4. DotDProcessor - concatena .d.tmpl/
+				// 4. DotDProcessor - concatenates .d.tmpl/
 				pipeline.AddPlugin(source.NewDotDProcessorPlugin(engine, cfg))
 
-				// 5. StrictConflictResolver - garante unicidade total
+				// 5. StrictConflictResolver - ensures total uniqueness
 				pipeline.AddPlugin(source.NewStrictConflictResolverPlugin())
 
 				// StateStore
@@ -148,14 +148,14 @@ func GetCommand() *cobra.Command {
 							return apply.ApplyHomeDconf(ctx)
 						},
 					},
-					// Hook para reload GTK theme
+					// Hook to reload GTK theme
 					&dotfiles.FuncHook{
 						AfterFn: func(ctx context.Context, actions []deployer.Action, execErr error) error {
 							if execErr != nil {
-								return nil // Não executar se houve erro
+								return nil // Don't execute if there was an error
 							}
 							if env.IsPhone(ctx) {
-								return nil // Não executar em phone
+								return nil // Don't execute on phone
 							}
 
 							home, _ := os.UserHomeDir()
@@ -186,7 +186,7 @@ func GetCommand() *cobra.Command {
 					},
 				}
 
-				// Criar manager com pipeline
+				// Create manager with pipeline
 				mgr, err := dotfiles.NewManager(dotfiles.Config{
 					Pipeline:   pipeline,
 					StateStore: stateStore,
@@ -196,7 +196,7 @@ func GetCommand() *cobra.Command {
 					return fmt.Errorf("failed to create manager: %w", err)
 				}
 
-				// Aplicar configurações
+				// Apply configurations
 				result, err := mgr.Apply(ctx, dotfiles.ApplyOptions{
 					DryRun: dryRun,
 				})
@@ -204,7 +204,7 @@ func GetCommand() *cobra.Command {
 					return err
 				}
 
-				// Mostrar resultado
+				// Show result
 				if result.FilesCreated > 0 || result.FilesUpdated > 0 || result.FilesDeleted > 0 || (showNoop && result.FilesNoOp > 0) {
 					orderedActions := deployer.SortActions(result.Actions)
 					w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)

--- a/cmd/workspaced/is/in_store.go
+++ b/cmd/workspaced/is/in_store.go
@@ -1,11 +1,13 @@
 package is
 
 import (
-	"fmt"
+	"errors"
 	"workspaced/pkg/env"
 
 	"github.com/spf13/cobra"
 )
+
+var errNotInStore = errors.New("not in store")
 
 func init() {
 	Registry.Register(func(parent *cobra.Command) {
@@ -14,7 +16,7 @@ func init() {
 			Short: "Check if dotfiles are in nix store",
 			RunE: func(c *cobra.Command, args []string) error {
 				if !env.IsInStore(c.Context()) {
-					return fmt.Errorf("not in store")
+					return errNotInStore
 				}
 				return nil
 			},

--- a/cmd/workspaced/is/phone.go
+++ b/cmd/workspaced/is/phone.go
@@ -1,11 +1,13 @@
 package is
 
 import (
-	"fmt"
+	"errors"
 	"workspaced/pkg/env"
 
 	"github.com/spf13/cobra"
 )
+
+var errNotPhone = errors.New("not phone")
 
 func init() {
 	Registry.Register(func(parent *cobra.Command) {
@@ -14,7 +16,7 @@ func init() {
 			Short: "Check if environment is a phone",
 			RunE: func(c *cobra.Command, args []string) error {
 				if !env.IsPhone(c.Context()) {
-					return fmt.Errorf("not phone")
+					return errNotPhone
 				}
 				return nil
 			},

--- a/cmd/workspaced/open/mise.go
+++ b/cmd/workspaced/open/mise.go
@@ -14,6 +14,7 @@ import (
 	"workspaced/pkg/driver/httpclient"
 	"workspaced/pkg/driver/shim/bash"
 	"workspaced/pkg/logging"
+	"workspaced/pkg/miseutil"
 
 	"github.com/spf13/cobra"
 )
@@ -37,7 +38,7 @@ func getMisePath() string {
 func installMise(ctx *cobra.Command) error {
 	misePath := getMisePath()
 	if misePath == "" {
-		return fmt.Errorf("could not determine mise install path")
+		return miseutil.ErrMiseInstallPathUnknown
 	}
 
 	// Create directory if it doesn't exist
@@ -63,7 +64,7 @@ func installMise(ctx *cobra.Command) error {
 	defer logging.Close(ctx.Context(), resp.Body, "url", "https://mise.run")
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download installer: HTTP %d", resp.StatusCode)
+		return fmt.Errorf("%w: HTTP %d", miseutil.ErrHTTPDownloadFailed, resp.StatusCode)
 	}
 
 	scriptBytes, err := io.ReadAll(resp.Body)
@@ -89,7 +90,7 @@ func installMise(ctx *cobra.Command) error {
 
 	// Verify installation
 	if _, err := os.Stat(misePath); os.IsNotExist(err) {
-		return fmt.Errorf("mise installation failed - binary not found at %s", misePath)
+		return fmt.Errorf("%w: binary not found at %s", miseutil.ErrMiseInstallFailed, misePath)
 	}
 
 	logger.Info("mise installed successfully", "path", misePath)
@@ -101,7 +102,7 @@ func ensureMise(ctx *cobra.Command) (string, error) {
 	logger := logging.GetLogger(ctx.Context())
 	misePath := getMisePath()
 	if misePath == "" {
-		return "", fmt.Errorf("could not determine mise install path")
+		return "", miseutil.ErrMiseInstallPathUnknown
 	}
 
 	// Check if mise exists

--- a/cmd/workspaced/selfupdate/root.go
+++ b/cmd/workspaced/selfupdate/root.go
@@ -3,6 +3,7 @@ package selfupdate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,6 +25,16 @@ import (
 	"workspaced/pkg/version"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	ErrGoVersionUnknown     = errors.New("could not determine Go version from build info")
+	ErrNoVersionsFound      = errors.New("no versions found")
+	ErrArtifactToolRequired = errors.New("github tool does not support ArtifactTool (needed for selfupdate)")
+	ErrNoArtifactFound      = errors.New("no artifact found for current platform")
+	ErrNoBinaryFound        = errors.New("no binary found")
+	ErrHTTPDownloadFailed   = errors.New("HTTP download failed")
+	ErrMiseInstallFailed    = errors.New("mise installation failed")
 )
 
 func GetCommand() *cobra.Command {
@@ -105,7 +116,7 @@ func buildAndInstallFromSource(ctx context.Context, srcPath string) error {
 	// Get build dependencies
 	goVersion := getGoVersion()
 	if goVersion == "" {
-		return fmt.Errorf("could not determine Go version from build info")
+		return ErrGoVersionUnknown
 	}
 
 	// Ensure mise is installed (auto-install if needed)
@@ -181,7 +192,7 @@ func updateFromGitHub(ctx context.Context, force bool) error {
 	}
 
 	if len(versions) == 0 {
-		return fmt.Errorf("no versions found")
+		return ErrNoVersionsFound
 	}
 
 	latestVersion := versions[0]
@@ -207,7 +218,7 @@ func updateFromGitHub(ctx context.Context, force bool) error {
 	// Use ArtifactTool + the shared SelectArtifact for platform selection.
 	at, ok := t.(backend.ArtifactTool)
 	if !ok {
-		return fmt.Errorf("github tool does not support ArtifactTool (needed for selfupdate)")
+		return ErrArtifactToolRequired
 	}
 
 	artifacts, err := at.ListArtifacts(ctx, latestVersion)
@@ -224,7 +235,7 @@ func updateFromGitHub(ctx context.Context, force bool) error {
 		for _, a := range artifacts {
 			available = append(available, fmt.Sprintf("%s/%s", a.OS, a.Arch))
 		}
-		return fmt.Errorf("no artifact found for %s/%s (available: %v)", runtime.GOOS, runtime.GOARCH, available)
+		return fmt.Errorf("%w: %s/%s (available: %v)", ErrNoArtifactFound, runtime.GOOS, runtime.GOARCH, available)
 	}
 
 	// Install to fixed location (not versioned)
@@ -348,7 +359,7 @@ func findBinary(dir string) (string, error) {
 		return candidates[0], nil
 	}
 
-	return "", fmt.Errorf("no binary found in %s", dir)
+	return "", fmt.Errorf("%w: %s", ErrNoBinaryFound, dir)
 }
 
 // ============================================================================
@@ -471,7 +482,7 @@ func installMise(ctx context.Context, misePath string) error {
 	defer logging.Close(ctx, resp.Body, "url", "https://mise.run")
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download installer: HTTP %d", resp.StatusCode)
+		return fmt.Errorf("%w: HTTP %d", ErrHTTPDownloadFailed, resp.StatusCode)
 	}
 
 	scriptBytes, err := io.ReadAll(resp.Body)
@@ -496,7 +507,7 @@ func installMise(ctx context.Context, misePath string) error {
 
 	// Verify installation
 	if _, err := os.Stat(misePath); err != nil {
-		return fmt.Errorf("mise installation failed - binary not found at %s", misePath)
+		return fmt.Errorf("%w: binary not found at %s", ErrMiseInstallFailed, misePath)
 	}
 
 	logger.Info("mise installed successfully", "path", misePath)

--- a/cmd/workspaced/utils/demo/progress.go
+++ b/cmd/workspaced/utils/demo/progress.go
@@ -18,12 +18,12 @@ func init() {
 			Run: func(cmd *cobra.Command, args []string) {
 				ctx := cmd.Context()
 				n := &notification.Notification{
-					Title: "Demo de Progresso",
+					Title: "Progress Demo",
 					Icon:  "utilities-terminal",
 				}
 				for i := 1; i <= 10; i++ {
 					percent := i * 10
-					n.Message = fmt.Sprintf("Passo %d de 10...", i)
+					n.Message = fmt.Sprintf("Step %d of 10...", i)
 					n.HasProgress = true
 					n.ID = 69
 					n.Progress = float64(percent) / 100.0
@@ -33,7 +33,7 @@ func init() {
 					}
 					time.Sleep(time.Second)
 				}
-				n.Message = "Demo concluída!"
+				n.Message = "Demo complete!"
 				n.Progress = 1.0
 				if err := notification.Notify(ctx, n); err != nil {
 					logger := logging.GetLogger(ctx)

--- a/cmd/workspaced/utils/history/ingest.go
+++ b/cmd/workspaced/utils/history/ingest.go
@@ -21,7 +21,7 @@ func init() {
 			Args:  cobra.ExactArgs(1),
 			RunE: func(c *cobra.Command, args []string) error {
 				source := args[0]
-				database, ok := c.Context().Value(types.DBKey).(*db.DB)
+				database, ok := db.FromContext(c.Context())
 				if !ok {
 					var err error
 					database, err = db.Open(c.Context())

--- a/cmd/workspaced/utils/history/list.go
+++ b/cmd/workspaced/utils/history/list.go
@@ -6,7 +6,6 @@ import (
 	"time"
 	"workspaced/pkg/db"
 	"workspaced/pkg/logging"
-	"workspaced/pkg/types"
 
 	"github.com/spf13/cobra"
 )
@@ -20,7 +19,7 @@ func init() {
 				limit, _ := c.Flags().GetInt32("limit")
 				asJSON, _ := c.Flags().GetBool("json")
 
-				database, ok := c.Context().Value(types.DBKey).(*db.DB)
+				database, ok := db.FromContext(c.Context())
 				if !ok {
 					var err error
 					database, err = db.Open(c.Context())

--- a/cmd/workspaced/utils/history/record.go
+++ b/cmd/workspaced/utils/history/record.go
@@ -40,7 +40,7 @@ func init() {
 					event.Cwd, _ = os.Getwd()
 				}
 
-				if database, ok := c.Context().Value(types.DBKey).(*db.DB); ok {
+				if database, ok := db.FromContext(c.Context()); ok {
 					return database.RecordHistory(c.Context(), event)
 				}
 

--- a/cmd/workspaced/utils/history/search.go
+++ b/cmd/workspaced/utils/history/search.go
@@ -1,17 +1,19 @@
 package history
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 	"workspaced/pkg/cmdregistry"
 	"workspaced/pkg/db"
 	"workspaced/pkg/logging"
-	"workspaced/pkg/types"
 
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
 )
+
+var errNoHistory = errors.New("no history found")
 
 var Registry cmdregistry.CommandRegistry
 
@@ -21,7 +23,7 @@ func init() {
 			Use:   "search [query]",
 			Short: "Search history using fuzzy finder",
 			RunE: func(c *cobra.Command, args []string) error {
-				database, ok := c.Context().Value(types.DBKey).(*db.DB)
+				database, ok := db.FromContext(c.Context())
 				if !ok {
 					var err error
 					database, err = db.Open(c.Context())
@@ -37,7 +39,7 @@ func init() {
 				}
 
 				if len(events) == 0 {
-					return fmt.Errorf("no history found")
+					return errNoHistory
 				}
 
 				// 2. Run fuzzy finder

--- a/cmd/workspaced/utils/nix/deploy.go
+++ b/cmd/workspaced/utils/nix/deploy.go
@@ -49,7 +49,7 @@ func init() {
 
 				n := notification.Notification{
 					Title:   "NixOS Deploy",
-					Message: fmt.Sprintf("Deploy concluído para: %s", strings.Join(nodes, ", ")),
+					Message: fmt.Sprintf("Deploy completed for: %s", strings.Join(nodes, ", ")),
 					Icon:    "nix-snowflake",
 				}
 				if err := notification.Notify(ctx, &n); err != nil {

--- a/cmd/workspaced/utils/nix/root.go
+++ b/cmd/workspaced/utils/nix/root.go
@@ -1,9 +1,15 @@
 package nix
 
 import (
+	"errors"
 	"workspaced/pkg/cmdregistry"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	errNoFlakeRef    = errors.New("no flake reference provided")
+	errNoBinaryFound = errors.New("no binary found")
 )
 
 var Registry cmdregistry.CommandRegistry

--- a/cmd/workspaced/utils/nix/rrun.go
+++ b/cmd/workspaced/utils/nix/rrun.go
@@ -22,7 +22,7 @@ func init() {
 			DisableFlagParsing: true,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if len(args) == 0 {
-					return fmt.Errorf("no flake reference provided")
+					return errNoFlakeRef
 				}
 				ctx := cmd.Context()
 				ref := args[0]
@@ -59,7 +59,7 @@ func init() {
 					// Guess binary name from package name or first file in bin/
 					entries, err := os.ReadDir(binDir)
 					if err != nil || len(entries) == 0 {
-						return fmt.Errorf("no binary found in %s", binDir)
+						return fmt.Errorf("%w: %s", errNoBinaryFound, binDir)
 					}
 					binary = entries[0].Name()
 				}

--- a/cmd/workspaced/utils/nix/run.go
+++ b/cmd/workspaced/utils/nix/run.go
@@ -21,7 +21,7 @@ func init() {
 			DisableFlagParsing: true,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if len(args) == 0 {
-					return fmt.Errorf("no flake reference provided")
+					return errNoFlakeRef
 				}
 				ctx := cmd.Context()
 				ref := args[0]
@@ -57,7 +57,7 @@ func init() {
 				if binary == "" {
 					entries, err := os.ReadDir(binDir)
 					if err != nil || len(entries) == 0 {
-						return fmt.Errorf("no binary found in %s", binDir)
+						return fmt.Errorf("%w: %s", errNoBinaryFound, binDir)
 					}
 					binary = entries[0].Name()
 				}

--- a/cmd/workspaced/utils/root.go
+++ b/cmd/workspaced/utils/root.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -144,7 +145,7 @@ func TryRemoteRaw(ctx context.Context, cmdName string, args []string) (string, b
 					// Run locally this time, next call will hit new daemon
 					return "", false, nil
 				}
-				return "", true, fmt.Errorf("%s", resp.Error)
+				return "", true, errors.New(resp.Error)
 			}
 			return "", true, nil
 		}

--- a/cmd/workspaced/utils/template/materialize.go
+++ b/cmd/workspaced/utils/template/materialize.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"workspaced/pkg/configcue"
@@ -11,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var errTargetRequired = errors.New("--target is required")
+
 func init() {
 	Registry.Register(
 		func(c *cobra.Command) {
@@ -20,7 +23,7 @@ func init() {
 			cmd := &cobra.Command{Use: "materialize", Short: "Materialize templates into a directory (low-level)", RunE: func(c *cobra.Command, args []string) error {
 				ctx := c.Context()
 				if targetDir == "" {
-					return fmt.Errorf("--target is required")
+					return errTargetRequired
 				}
 				cfg, err := configcue.LoadFiles(ctx, configPaths)
 				if err != nil {

--- a/pkg/backup/action_archive.go
+++ b/pkg/backup/action_archive.go
@@ -2,12 +2,20 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	execdriver "workspaced/pkg/driver/exec"
 	"workspaced/pkg/driver/notification"
+)
+
+var (
+	// ErrArchiveNeedsInputAndOutput is returned when an archive action is missing input_dir or output.
+	ErrArchiveNeedsInputAndOutput = errors.New("archive action requires input_dir and output")
+	// ErrUnsupportedArchiveFormat is returned when an unsupported archive format is requested.
+	ErrUnsupportedArchiveFormat = errors.New("unsupported archive format")
 )
 
 func init() {
@@ -23,10 +31,10 @@ type ArchiveAction struct {
 
 func (action ArchiveAction) Run(ctx context.Context, _ *notification.Notification) error {
 	if strings.TrimSpace(action.InputDir) == "" || strings.TrimSpace(action.Output) == "" {
-		return fmt.Errorf("archive action requires input_dir and output")
+		return ErrArchiveNeedsInputAndOutput
 	}
 	if action.Format != "tar" {
-		return fmt.Errorf("unsupported archive format: %s", action.Format)
+		return fmt.Errorf("%w: %s", ErrUnsupportedArchiveFormat, action.Format)
 	}
 	parent := filepath.Dir(action.InputDir)
 	base := filepath.Base(action.InputDir)

--- a/pkg/backup/action_git_sync.go
+++ b/pkg/backup/action_git_sync.go
@@ -12,6 +12,11 @@ import (
 	"workspaced/pkg/driver/notification"
 )
 
+var (
+	// ErrGitRepoSyncNeedsSrcAndDst is returned when a git_repo_sync action is missing src or dst.
+	ErrGitRepoSyncNeedsSrcAndDst = errors.New("git_repo_sync requires src and dst")
+)
+
 func init() {
 	registerActionProvider[GitRepoSyncAction]("git_repo_sync")
 
@@ -25,7 +30,7 @@ type GitRepoSyncAction struct {
 
 func (a GitRepoSyncAction) Run(ctx context.Context, _ *notification.Notification) error {
 	if strings.TrimSpace(a.Src) == "" || strings.TrimSpace(a.Dst) == "" {
-		return fmt.Errorf("git_repo_sync requires src and dst")
+		return ErrGitRepoSyncNeedsSrcAndDst
 	}
 	if err := ensureRepoCloned(ctx, a.Src, a.Dst); err != nil {
 		return err

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,6 +15,11 @@ import (
 	"workspaced/pkg/driver/notification"
 	"workspaced/pkg/logging"
 	"workspaced/pkg/taskgroup"
+)
+
+var (
+	// ErrUnknownBackupActionKind is returned when a backup action has an unrecognized kind.
+	ErrUnknownBackupActionKind = errors.New("unknown backup action kind")
 )
 
 type BackupAction interface {
@@ -153,7 +159,7 @@ func decodeBackupActions(rawActions []json.RawMessage) ([]BackupAction, error) {
 		}
 		provider, ok := actionProviders[base.Kind]
 		if !ok {
-			return nil, fmt.Errorf("unknown backup action kind: %s", base.Kind)
+			return nil, fmt.Errorf("%w: %s", ErrUnknownBackupActionKind, base.Kind)
 		}
 		action, err := provider(raw)
 		if err != nil {
@@ -166,7 +172,7 @@ func decodeBackupActions(rawActions []json.RawMessage) ([]BackupAction, error) {
 
 func Rsync(ctx context.Context, src, dst string, n *notification.Notification, extraArgs ...string) (string, error) {
 	if strings.TrimSpace(src) == "" || strings.TrimSpace(dst) == "" {
-		return "", fmt.Errorf("rsync requires src and dst")
+		return "", ErrRsyncNeedsSrcAndDst
 	}
 	logger := logging.GetLogger(ctx)
 	logger.Info("rsync sync", "from", src, "to", dst)

--- a/pkg/checks/check.go
+++ b/pkg/checks/check.go
@@ -11,6 +11,7 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"workspaced/pkg/compat"
 )
@@ -33,6 +34,9 @@ var ErrIncompatible = compat.ErrIncompatible
 
 // ErrNotApplicable is kept as alias for readability in check code.
 var ErrNotApplicable = ErrIncompatible
+
+// ErrToolNotAvailable indicates a required tool binary is not available.
+var ErrToolNotAvailable = errors.New("required tool not available")
 
 // providers holds the registry of implementations.
 // Since registration happens only during init(), we don't need mutexes for runtime access.

--- a/pkg/checks/lint/govulncheck/provider.go
+++ b/pkg/checks/lint/govulncheck/provider.go
@@ -46,7 +46,7 @@ func (p *Provider) Detect(ctx context.Context, dir string) error {
 
 func (p *Provider) Run(ctx context.Context, dir string) (*sarif.Run, error) {
 	if !exec.IsBinaryAvailable(ctx, "go") {
-		return nil, fmt.Errorf("go binary not available for govulncheck")
+		return nil, fmt.Errorf("%w: go binary not available for govulncheck", checks.ErrToolNotAvailable)
 	}
 
 	cmd, err := exec.Run(ctx, "go", "run", "golang.org/x/vuln/cmd/govulncheck@v1.1.4", "--format", "sarif", "./...")

--- a/pkg/checks/lint/shellcheck/shellcheck.go
+++ b/pkg/checks/lint/shellcheck/shellcheck.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
 )
+
+var ErrShellcheckFailed = errors.New("shellcheck failed")
 
 // Provider implements the lint.Linter interface for shell scripts.
 // It executes 'shellcheck' using the workspaced tool system.
@@ -119,9 +122,9 @@ func (p *Provider) Run(ctx context.Context, dir string) (*sarif.Run, error) {
 	if len(output) == 0 {
 		// If no output but stderr has content, likely a real error
 		if stderr.Len() > 0 {
-			errStr := fmt.Errorf("shellcheck failed: %s", stderr.String())
-			logging.ReportError(ctx, errStr, slog.String("context", "shellcheck execution failed"))
-			return nil, errStr
+			err := fmt.Errorf("%w: %s", ErrShellcheckFailed, stderr.String())
+			logging.ReportError(ctx, err, slog.String("context", "shellcheck execution failed"))
+			return nil, err
 		}
 		return nil, nil
 	}

--- a/pkg/configcue/config.go
+++ b/pkg/configcue/config.go
@@ -3,6 +3,7 @@ package configcue
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,11 @@ import (
 	"workspaced/pkg/driver"
 	"workspaced/pkg/env"
 	"workspaced/pkg/taskgroup"
+)
+
+var (
+	ErrKeyNotFound = errors.New("key not found in config")
+	ErrKeyNotMap   = errors.New("config key is not a map")
 )
 
 type Config struct {
@@ -47,11 +53,11 @@ func (c *Config) Lookup(key string) (any, error) {
 	for _, part := range strings.Split(key, ".") {
 		m, ok := current.(map[string]any)
 		if !ok {
-			return nil, fmt.Errorf("key %q not found or not a map", key)
+			return nil, fmt.Errorf("%w: %q", ErrKeyNotMap, key)
 		}
 		next, ok := m[part]
 		if !ok {
-			return nil, fmt.Errorf("key %q not found in config", key)
+			return nil, fmt.Errorf("%w: %q", ErrKeyNotFound, key)
 		}
 		current = next
 	}

--- a/pkg/configcue/loader.go
+++ b/pkg/configcue/loader.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"os"
@@ -30,6 +31,8 @@ import (
 	"cuelang.org/go/cue/parser"
 	"cuelang.org/go/cue/token"
 )
+
+var ErrInvalidInputSpec = errors.New("invalid input spec")
 
 //go:embed schema.cue prelude_common.cue prelude_home.cue prelude_codebase.cue
 var schemaFS embed.FS
@@ -815,7 +818,7 @@ func resolveRuntimeInputs(configValue cue.Value, paths []string, discovered []La
 
 		provider, target, ok := parseInputSpec(spec)
 		if !ok {
-			return nil, fmt.Errorf("resolve runtime input %q: invalid from %q", name, spec)
+			return nil, fmt.Errorf("resolve runtime input %q: %w: %q", name, ErrInvalidInputSpec, spec)
 		}
 		switch provider {
 		case "github":

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -20,6 +20,19 @@ import (
 //go:embed migrations/*.sql
 var migrationFS embed.FS
 
+type dbKey struct{}
+
+// WithDB returns a context that carries the given database connection.
+func WithDB(ctx context.Context, database *DB) context.Context {
+	return context.WithValue(ctx, dbKey{}, database)
+}
+
+// FromContext retrieves the database connection from the context.
+func FromContext(ctx context.Context) (*DB, bool) {
+	database, ok := ctx.Value(dbKey{}).(*DB)
+	return database, ok
+}
+
 type DB struct {
 	*sql.DB
 	Queries *sqlc.Queries

--- a/pkg/deployer/executor.go
+++ b/pkg/deployer/executor.go
@@ -12,7 +12,7 @@ import (
 	"workspaced/pkg/taskgroup"
 )
 
-// prettyPath converte caminho absoluto para relativo ao $HOME
+// prettyPath converts an absolute path to a path relative to $HOME.
 func prettyPath(path string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -26,10 +26,10 @@ func prettyPath(path string) string {
 	return path
 }
 
-// Executor executa ações de deployment
+// Executor applies deployment actions.
 type Executor struct{}
 
-// NewExecutor cria um novo executor
+// NewExecutor creates a new Executor.
 func NewExecutor() *Executor {
 	return &Executor{}
 }

--- a/pkg/deployer/planner.go
+++ b/pkg/deployer/planner.go
@@ -12,10 +12,10 @@ import (
 	"workspaced/pkg/taskgroup"
 )
 
-// Planner compara estado atual vs desejado e gera ações
+// Planner compares current state with desired state and generates actions.
 type Planner struct{}
 
-// NewPlanner cria um novo planner
+// NewPlanner creates a new Planner.
 func NewPlanner() *Planner {
 	return &Planner{}
 }

--- a/pkg/deployer/state.go
+++ b/pkg/deployer/state.go
@@ -7,26 +7,26 @@ import (
 	"path/filepath"
 )
 
-// StateStore é a interface para persistência de estado
+// StateStore is the interface for state persistence.
 type StateStore interface {
-	// Load carrega estado atual
+	// Load loads the current state.
 	Load() (*State, error)
 
-	// Save persiste estado
+	// Save persists the state.
 	Save(state *State) error
 
-	// Path retorna caminho/identificador do store (para logging)
+	// Path returns the path or identifier of the store (for logging).
 	Path() string
 }
 
-// FileStateStore implementa StateStore usando arquivo JSON
+// FileStateStore implements StateStore using a JSON file.
 type FileStateStore struct {
 	path string
 }
 
-// NewFileStateStore cria um FileStateStore
+// NewFileStateStore creates a FileStateStore.
 func NewFileStateStore(path string) (*FileStateStore, error) {
-	// Expand env vars e ~
+	// Expand env vars and ~
 	expanded := os.ExpandEnv(path)
 	if len(expanded) > 0 && expanded[0] == '~' {
 		home, err := os.UserHomeDir()
@@ -36,7 +36,7 @@ func NewFileStateStore(path string) (*FileStateStore, error) {
 		expanded = filepath.Join(home, expanded[1:])
 	}
 
-	// Garantir que diretório pai existe
+	// Ensure parent directory exists
 	dir := filepath.Dir(expanded)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create state directory: %w", err)
@@ -48,7 +48,7 @@ func NewFileStateStore(path string) (*FileStateStore, error) {
 func (s *FileStateStore) Load() (*State, error) {
 	state := &State{Files: make(map[string]ManagedInfo)}
 
-	// Se arquivo não existe, retorna estado vazio
+	// If the file does not exist, return an empty state
 	if _, err := os.Stat(s.path); os.IsNotExist(err) {
 		return state, nil
 	}
@@ -62,7 +62,7 @@ func (s *FileStateStore) Load() (*State, error) {
 		return nil, fmt.Errorf("failed to parse state file: %w", err)
 	}
 
-	// Garantir mapa não é nil
+	// Ensure map is not nil
 	if state.Files == nil {
 		state.Files = make(map[string]ManagedInfo)
 	}
@@ -87,13 +87,13 @@ func (s *FileStateStore) Path() string {
 	return s.path
 }
 
-// MemoryStateStore implementa StateStore em memória (útil para testes)
+// MemoryStateStore implements StateStore in memory (useful for tests).
 type MemoryStateStore struct {
 	state *State
 	id    string
 }
 
-// NewMemoryStateStore cria um MemoryStateStore
+// NewMemoryStateStore creates a MemoryStateStore.
 func NewMemoryStateStore(id string) *MemoryStateStore {
 	return &MemoryStateStore{
 		state: &State{Files: make(map[string]ManagedInfo)},

--- a/pkg/deployer/types.go
+++ b/pkg/deployer/types.go
@@ -6,7 +6,7 @@ import (
 	"workspaced/pkg/source"
 )
 
-// ActionType representa tipo de ação no deployment
+// ActionType represents the kind of action in a deployment plan.
 type ActionType int
 
 const (
@@ -30,25 +30,25 @@ func (a ActionType) String() string {
 	return "?"
 }
 
-// DesiredState alias para source.DesiredState
+// DesiredState is an alias for source.DesiredState.
 type DesiredState = source.DesiredState
 
-// Helper para pegar o target path de um DesiredState
+// GetTarget returns the full target path for a DesiredState.
 func GetTarget(d DesiredState) string {
 	return filepath.Join(d.File.TargetBase(), d.File.RelPath())
 }
 
-// ManagedInfo contém informações sobre arquivo gerenciado
+// ManagedInfo holds metadata about a managed file.
 type ManagedInfo struct {
 	SourceInfo string `json:"source_info"`
 }
 
-// State representa estado atual do sistema
+// State represents the current state of the managed file system.
 type State struct {
 	Files map[string]ManagedInfo `json:"files"` // Key: Target (Absolute path)
 }
 
-// Action representa ação a ser executada
+// Action represents a single deployment action to be executed.
 type Action struct {
 	Type    ActionType
 	Target  string
@@ -83,5 +83,5 @@ func SortActions(actions []Action) []Action {
 	return ordered
 }
 
-// Provider alias para source.Provider
+// Provider is an alias for source.Provider.
 type Provider = source.Provider

--- a/pkg/deployer/types_test.go
+++ b/pkg/deployer/types_test.go
@@ -1,0 +1,65 @@
+package deployer
+
+import "testing"
+
+func TestSortActions(t *testing.T) {
+	actions := []Action{
+		{Type: ActionCreate, Target: "/b"},
+		{Type: ActionDelete, Target: "/a"},
+		{Type: ActionNoop, Target: "/c"},
+		{Type: ActionUpdate, Target: "/d"},
+		{Type: ActionCreate, Target: "/a"},
+		{Type: ActionDelete, Target: "/b"},
+	}
+
+	sorted := SortActions(actions)
+
+	// Verify order: Delete < Update < Create < Noop, then by Target
+	expected := []struct {
+		actionType ActionType
+		target     string
+	}{
+		{ActionDelete, "/a"},
+		{ActionDelete, "/b"},
+		{ActionUpdate, "/d"},
+		{ActionCreate, "/a"},
+		{ActionCreate, "/b"},
+		{ActionNoop, "/c"},
+	}
+
+	if len(sorted) != len(expected) {
+		t.Fatalf("got %d actions, want %d", len(sorted), len(expected))
+	}
+
+	for i, want := range expected {
+		if sorted[i].Type != want.actionType || sorted[i].Target != want.target {
+			t.Errorf("sorted[%d] = {%s, %s}, want {%s, %s}",
+				i, sorted[i].Type, sorted[i].Target, want.actionType, want.target)
+		}
+	}
+
+	// Verify original slice is not modified
+	if actions[0].Type != ActionCreate || actions[0].Target != "/b" {
+		t.Error("SortActions mutated the original slice")
+	}
+}
+
+func TestActionTypeString(t *testing.T) {
+	tests := []struct {
+		action ActionType
+		want   string
+	}{
+		{ActionCreate, "+"},
+		{ActionUpdate, "*"},
+		{ActionDelete, "-"},
+		{ActionNoop, " "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.action.String()
+			if got != tt.want {
+				t.Errorf("ActionType(%d).String() = %q, want %q", tt.action, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/dotfiles/hooks.go
+++ b/pkg/dotfiles/hooks.go
@@ -5,16 +5,16 @@ import (
 	"workspaced/pkg/deployer"
 )
 
-// Hook permite executar código antes/depois do deployment
+// Hook allows executing code before/after deployment.
 type Hook interface {
-	// Before é chamado antes de executar actions
+	// Before is called before executing actions.
 	Before(ctx context.Context, actions []deployer.Action) error
 
-	// After é chamado após executar actions (mesmo se houver erro)
+	// After is called after executing actions (even if there was an error).
 	After(ctx context.Context, applied []deployer.Action, err error) error
 }
 
-// FuncHook implementa Hook usando funções
+// FuncHook implements Hook using functions.
 type FuncHook struct {
 	BeforeFn func(ctx context.Context, actions []deployer.Action) error
 	AfterFn  func(ctx context.Context, applied []deployer.Action, err error) error

--- a/pkg/dotfiles/manager.go
+++ b/pkg/dotfiles/manager.go
@@ -2,6 +2,7 @@ package dotfiles
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 	"workspaced/pkg/deployer"
@@ -9,7 +10,14 @@ import (
 	"workspaced/pkg/source"
 )
 
-// Manager é a API principal para gerenciamento de dotfiles
+var (
+	// ErrPipelineRequired is returned when a Manager is created without a pipeline.
+	ErrPipelineRequired = errors.New("pipeline is required")
+	// ErrStateStoreRequired is returned when a Manager is created without a state store.
+	ErrStateStoreRequired = errors.New("state store is required")
+)
+
+// Manager is the main API for dotfiles management.
 type Manager struct {
 	pipeline   *source.Pipeline
 	stateStore deployer.StateStore
@@ -18,26 +26,26 @@ type Manager struct {
 	hooks      []Hook
 }
 
-// Config configura o Manager
+// Config configures the Manager.
 type Config struct {
-	// Pipeline de plugins
+	// Pipeline of plugins.
 	Pipeline *source.Pipeline
 
-	// State store para persistência
+	// StateStore for persistence.
 	StateStore deployer.StateStore
 
-	// Hooks opcionais
+	// Hooks (optional).
 	Hooks []Hook
 }
 
-// NewManager cria um novo manager
+// NewManager creates a new Manager.
 func NewManager(cfg Config) (*Manager, error) {
 	if cfg.Pipeline == nil {
-		return nil, fmt.Errorf("pipeline is required")
+		return nil, ErrPipelineRequired
 	}
 
 	if cfg.StateStore == nil {
-		return nil, fmt.Errorf("state store is required")
+		return nil, ErrStateStoreRequired
 	}
 
 	return &Manager{
@@ -49,13 +57,13 @@ func NewManager(cfg Config) (*Manager, error) {
 	}, nil
 }
 
-// ApplyOptions configura execução do Apply
+// ApplyOptions configures Apply execution.
 type ApplyOptions struct {
-	DryRun   bool // Se true, apenas mostra o que seria feito
-	ShowDiff bool // Se true, mostra diff detalhado
+	DryRun   bool // If true, only shows what would be done.
+	ShowDiff bool // If true, shows a detailed diff.
 }
 
-// ApplyResult contém resultado do Apply
+// ApplyResult contains the result of Apply.
 type ApplyResult struct {
 	FilesCreated int
 	FilesUpdated int
@@ -65,12 +73,12 @@ type ApplyResult struct {
 	Error        error
 }
 
-// Apply executa o ciclo completo de deployment
+// Apply runs the full deployment cycle.
 func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 	logger := logging.GetLogger(ctx)
 	result := &ApplyResult{}
 
-	// 1. Executar pipeline
+	// 1. Run pipeline
 	logger.Info("running pipeline", "plugins", len(m.pipeline.GetPlugins()))
 	files, err := m.pipeline.Run(ctx, []source.File{})
 	if err != nil {
@@ -80,7 +88,7 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 
 	logger.Info("pipeline completed", "files", len(files))
 
-	// 2. Converter source.File para deployer.DesiredState
+	// 2. Convert source.File to deployer.DesiredState
 	desired := make([]deployer.DesiredState, len(files))
 	for i, f := range files {
 		desired[i] = deployer.DesiredState{
@@ -88,7 +96,7 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 		}
 	}
 
-	// 3. Carregar estado atual
+	// 3. Load current state
 	logger.Info("loading state", "store", m.stateStore.Path())
 	state, err := m.stateStore.Load()
 	if err != nil {
@@ -96,7 +104,7 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 		return result, fmt.Errorf("failed to load state: %w", err)
 	}
 
-	// 4. Planejar ações
+	// 4. Plan actions
 	logger.Info("planning actions")
 	planStart := time.Now()
 	actions, err := m.planner.Plan(ctx, desired, state)
@@ -108,7 +116,7 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 
 	result.Actions = actions
 
-	// Contar ações
+	// Count actions
 	for _, a := range actions {
 		switch a.Type {
 		case deployer.ActionCreate:
@@ -135,13 +143,13 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 		"delete", result.FilesDeleted,
 	)
 
-	// Dry-run: para aqui
+	// Dry-run: stop here
 	if opts.DryRun {
 		logger.Info("dry-run: skipping execution")
 		return result, nil
 	}
 
-	// 5. Executar hooks Before
+	// 5. Execute Before hooks
 	for _, hook := range m.hooks {
 		if err := hook.Before(ctx, actions); err != nil {
 			result.Error = err
@@ -149,15 +157,15 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 		}
 	}
 
-	// 6. Executar ações
+	// 6. Execute actions
 	logger.Info("executing actions")
 	execErr := m.executor.Execute(ctx, actions, state)
 
-	// 7. Executar hooks After (mesmo se houver erro)
+	// 7. Execute After hooks (even if there was an error)
 	for _, hook := range m.hooks {
 		if err := hook.After(ctx, actions, execErr); err != nil {
 			logger.Error("hook after failed", "error", err)
-			// Continua executando outros hooks
+			// Continue executing other hooks
 		}
 	}
 
@@ -166,7 +174,7 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 		return result, fmt.Errorf("failed to execute: %w", execErr)
 	}
 
-	// 8. Salvar estado
+	// 8. Save state
 	logger.Info("saving state")
 	if err := m.stateStore.Save(state); err != nil {
 		result.Error = err
@@ -177,12 +185,12 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 	return result, nil
 }
 
-// GetPipeline retorna pipeline configurado
+// GetPipeline returns the configured pipeline.
 func (m *Manager) GetPipeline() *source.Pipeline {
 	return m.pipeline
 }
 
-// GetStateStore retorna state store configurado
+// GetStateStore returns the configured state store.
 func (m *Manager) GetStateStore() deployer.StateStore {
 	return m.stateStore
 }

--- a/pkg/driver/audio/pulse/driver.go
+++ b/pkg/driver/audio/pulse/driver.go
@@ -15,22 +15,22 @@ import (
 var sink = "@DEFAULT_SINK@"
 
 func init() {
-	driver.Register[audio.Driver](&Provider{})
+	driver.Register[audio.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "audio_pulse" }
-func (p *Provider) Name() string { return "PulseAudio (pactl)" }
+func (p *Factory) ID() string   { return "audio_pulse" }
+func (p *Factory) Name() string { return "PulseAudio (pactl)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "pactl") {
 		return fmt.Errorf("%w: pactl not found", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (audio.Driver, error) {
+func (p *Factory) New(ctx context.Context) (audio.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/battery/battery.go
+++ b/pkg/driver/battery/battery.go
@@ -2,6 +2,11 @@ package battery
 
 import (
 	"context"
+	"errors"
+)
+
+var (
+	ErrNoBattery = errors.New("no battery found")
 )
 
 type Driver interface {

--- a/pkg/driver/battery/linux/driver.go
+++ b/pkg/driver/battery/linux/driver.go
@@ -11,16 +11,16 @@ import (
 )
 
 func init() {
-	driver.Register[battery.Driver](&Provider{})
+	driver.Register[battery.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "battery_linux" }
-func (p *Provider) Name() string { return "linux" }
+func (p *Factory) ID() string   { return "battery_linux" }
+func (p *Factory) Name() string { return "linux" }
 
-// CheckCompatibility implements [driver.DriverProvider].
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+// CheckCompatibility implements [driver.DriverFactory].
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	matches, _ := filepath.Glob("/sys/class/power_supply/BAT*/status")
 	if len(matches) == 0 {
 		return fmt.Errorf("%w: /sys/class/power_supply/BAT*/status", driver.ErrIncompatible)
@@ -28,8 +28,8 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-// New implements [driver.DriverProvider].
-func (p *Provider) New(ctx context.Context) (battery.Driver, error) {
+// New implements [driver.DriverFactory].
+func (p *Factory) New(ctx context.Context) (battery.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -41,7 +41,7 @@ type Driver struct{}
 func (d *Driver) BatteryStatus(ctx context.Context) (battery.Status, error) {
 	matches, _ := filepath.Glob("/sys/class/power_supply/BAT*/status")
 	if len(matches) == 0 {
-		return battery.Unknown, fmt.Errorf("no battery found")
+		return battery.Unknown, battery.ErrNoBattery
 	}
 
 	// For now just get the first one

--- a/pkg/driver/brightness/brightness.go
+++ b/pkg/driver/brightness/brightness.go
@@ -2,6 +2,11 @@ package brightness
 
 import (
 	"context"
+	"errors"
+)
+
+var (
+	ErrDeviceNotFound = errors.New("brightness device not found")
 )
 
 type Device struct {

--- a/pkg/driver/brightness/brightnessctl/driver.go
+++ b/pkg/driver/brightness/brightnessctl/driver.go
@@ -11,22 +11,22 @@ import (
 )
 
 func init() {
-	driver.Register[brightness.Driver](&Provider{})
+	driver.Register[brightness.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "brightness_ctl" }
-func (p *Provider) Name() string { return "brightnessctl" }
+func (p *Factory) ID() string   { return "brightness_ctl" }
+func (p *Factory) Name() string { return "brightnessctl" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "brightnessctl") {
 		return fmt.Errorf("%w: brightnessctl not found", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (brightness.Driver, error) {
+func (p *Factory) New(ctx context.Context) (brightness.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -58,7 +58,7 @@ func (d *Driver) Status(ctx context.Context) (*brightness.Device, error) {
 			Brightness: float64(l) / 100,
 		}, nil
 	}
-	return nil, fmt.Errorf("failed to find brightness device")
+	return nil, brightness.ErrDeviceNotFound
 }
 
 func (d *Driver) SetBrightness(ctx context.Context, level float64) error {

--- a/pkg/driver/camera/linux/driver.go
+++ b/pkg/driver/camera/linux/driver.go
@@ -19,15 +19,15 @@ import (
 )
 
 func init() {
-	driver.Register[cameraapi.Driver](&Provider{})
+	driver.Register[cameraapi.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "v4l-ffmpeg" }
-func (p *Provider) Name() string { return "V4L2 + ffmpeg" }
+func (p *Factory) ID() string   { return "v4l-ffmpeg" }
+func (p *Factory) Name() string { return "V4L2 + ffmpeg" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if runtime.GOOS != "linux" {
 		return fmt.Errorf("%w: linux is required", driver.ErrIncompatible)
 	}
@@ -37,7 +37,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (cameraapi.Driver, error) {
+func (p *Factory) New(ctx context.Context) (cameraapi.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/clipboard/termux/driver.go
+++ b/pkg/driver/clipboard/termux/driver.go
@@ -13,22 +13,22 @@ import (
 )
 
 func init() {
-	driver.Register[clipboard.Driver](&Provider{})
+	driver.Register[clipboard.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "clipboard_termux" }
-func (p *Provider) Name() string { return "Termux" }
+func (p *Factory) ID() string   { return "clipboard_termux" }
+func (p *Factory) Name() string { return "Termux" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("TERMUX_VERSION") == "" && !execdriver.IsBinaryAvailable(ctx, "termux-clipboard-set") {
 		return fmt.Errorf("%w: termux not detected", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (clipboard.Driver, error) {
+func (p *Factory) New(ctx context.Context) (clipboard.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/clipboard/wlcopy/driver.go
+++ b/pkg/driver/clipboard/wlcopy/driver.go
@@ -16,15 +16,15 @@ import (
 )
 
 func init() {
-	driver.Register[clipboard.Driver](&Provider{})
+	driver.Register[clipboard.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "clipboard_wlcopy" }
-func (p *Provider) Name() string { return "Wayland (wl-copy)" }
+func (p *Factory) ID() string   { return "clipboard_wlcopy" }
+func (p *Factory) Name() string { return "Wayland (wl-copy)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: WAYLAND_DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -34,7 +34,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (clipboard.Driver, error) {
+func (p *Factory) New(ctx context.Context) (clipboard.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/clipboard/xclip/driver.go
+++ b/pkg/driver/clipboard/xclip/driver.go
@@ -15,23 +15,23 @@ import (
 )
 
 func init() {
-	driver.Register[clipboard.Driver](&Provider{})
+	driver.Register[clipboard.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "clipboard_xclip" }
-func (p *Provider) Name() string { return "X11 (xclip)" }
+func (p *Factory) ID() string   { return "clipboard_xclip" }
+func (p *Factory) Name() string { return "X11 (xclip)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "xclip") {
-		return fmt.Errorf("xclip binary not found")
+		return fmt.Errorf("%w: xclip", driver.ErrIncompatible)
 	}
 	// Fallback driver, usually always valid if binary exists
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (clipboard.Driver, error) {
+func (p *Factory) New(ctx context.Context) (clipboard.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/dialog/rofi/driver.go
+++ b/pkg/driver/dialog/rofi/driver.go
@@ -11,23 +11,23 @@ import (
 )
 
 func init() {
-	driver.Register[dialog.Chooser](&ChooserProvider{})
-	driver.Register[dialog.Driver](&FullDriverProvider{})
+	driver.Register[dialog.Chooser](&ChooserFactory{})
+	driver.Register[dialog.Driver](&FullDriverFactory{})
 }
 
-type ChooserProvider struct{}
+type ChooserFactory struct{}
 
-func (p *ChooserProvider) ID() string                                      { return "rofi" }
-func (p *ChooserProvider) Name() string                                    { return "Rofi" }
-func (p *ChooserProvider) CheckCompatibility(ctx context.Context) error    { return checkRofi(ctx) }
-func (p *ChooserProvider) New(ctx context.Context) (dialog.Chooser, error) { return &Driver{}, nil }
+func (p *ChooserFactory) ID() string                                      { return "rofi" }
+func (p *ChooserFactory) Name() string                                    { return "Rofi" }
+func (p *ChooserFactory) CheckCompatibility(ctx context.Context) error    { return checkRofi(ctx) }
+func (p *ChooserFactory) New(ctx context.Context) (dialog.Chooser, error) { return &Driver{}, nil }
 
-type FullDriverProvider struct{}
+type FullDriverFactory struct{}
 
-func (p *FullDriverProvider) ID() string                                     { return "rofi" }
-func (p *FullDriverProvider) Name() string                                   { return "Rofi" }
-func (p *FullDriverProvider) CheckCompatibility(ctx context.Context) error   { return checkRofi(ctx) }
-func (p *FullDriverProvider) New(ctx context.Context) (dialog.Driver, error) { return &Driver{}, nil }
+func (p *FullDriverFactory) ID() string                                     { return "rofi" }
+func (p *FullDriverFactory) Name() string                                   { return "Rofi" }
+func (p *FullDriverFactory) CheckCompatibility(ctx context.Context) error   { return checkRofi(ctx) }
+func (p *FullDriverFactory) New(ctx context.Context) (dialog.Driver, error) { return &Driver{}, nil }
 
 func checkRofi(ctx context.Context) error {
 	if executil.GetEnv(ctx, "DISPLAY") == "" && executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {

--- a/pkg/driver/dialog/terminal/driver.go
+++ b/pkg/driver/dialog/terminal/driver.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -13,34 +14,34 @@ import (
 )
 
 func init() {
-	driver.Register[dialog.Chooser](&ChooserProvider{})
-	driver.Register[dialog.Prompter](&PrompterProvider{})
-	driver.Register[dialog.Confirmer](&ConfirmerProvider{})
+	driver.Register[dialog.Chooser](&ChooserFactory{})
+	driver.Register[dialog.Prompter](&PrompterFactory{})
+	driver.Register[dialog.Confirmer](&ConfirmerFactory{})
 }
 
-type baseProvider struct{}
+type baseFactory struct{}
 
-func (p *baseProvider) ID() string { return "terminal" }
+func (p *baseFactory) ID() string { return "terminal" }
 
-func (p *baseProvider) CheckCompatibility(ctx context.Context) error {
-	// Sempre compatível, mas com peso 0 para ser fallback
+func (p *baseFactory) CheckCompatibility(ctx context.Context) error {
+	// Always compatible, but with weight 0 so it acts as fallback
 	return nil
 }
 
-type ChooserProvider struct{ baseProvider }
+type ChooserFactory struct{ baseFactory }
 
-func (p *ChooserProvider) Name() string                                    { return "Terminal (Fuzzy)" }
-func (p *ChooserProvider) New(ctx context.Context) (dialog.Chooser, error) { return &Driver{}, nil }
+func (p *ChooserFactory) Name() string                                    { return "Terminal (Fuzzy)" }
+func (p *ChooserFactory) New(ctx context.Context) (dialog.Chooser, error) { return &Driver{}, nil }
 
-type PrompterProvider struct{ baseProvider }
+type PrompterFactory struct{ baseFactory }
 
-func (p *PrompterProvider) Name() string                                     { return "Terminal (Stdin)" }
-func (p *PrompterProvider) New(ctx context.Context) (dialog.Prompter, error) { return &Driver{}, nil }
+func (p *PrompterFactory) Name() string                                     { return "Terminal (Stdin)" }
+func (p *PrompterFactory) New(ctx context.Context) (dialog.Prompter, error) { return &Driver{}, nil }
 
-type ConfirmerProvider struct{ baseProvider }
+type ConfirmerFactory struct{ baseFactory }
 
-func (p *ConfirmerProvider) Name() string                                      { return "Terminal (y/n)" }
-func (p *ConfirmerProvider) New(ctx context.Context) (dialog.Confirmer, error) { return &Driver{}, nil }
+func (p *ConfirmerFactory) Name() string                                      { return "Terminal (y/n)" }
+func (p *ConfirmerFactory) New(ctx context.Context) (dialog.Confirmer, error) { return &Driver{}, nil }
 
 // Driver implements Chooser, Prompter and Confirmer
 type Driver struct{}
@@ -80,10 +81,15 @@ func (d *Driver) Confirm(ctx context.Context, message string) (bool, error) {
 	return false, scanner.Err()
 }
 
+var (
+	ErrRunAppNotImplemented      = errors.New("RunApp not implemented for terminal driver")
+	ErrSwitchWindowNotImplemented = errors.New("SwitchWindow not implemented for terminal driver")
+)
+
 // Legacy compatibility for Driver interface
 func (d *Driver) RunApp(ctx context.Context) error {
-	return fmt.Errorf("RunApp not implemented for Terminal")
+	return ErrRunAppNotImplemented
 }
 func (d *Driver) SwitchWindow(ctx context.Context) error {
-	return fmt.Errorf("SwitchWindow not implemented for Terminal")
+	return ErrSwitchWindowNotImplemented
 }

--- a/pkg/driver/dialog/wofi/driver.go
+++ b/pkg/driver/dialog/wofi/driver.go
@@ -11,23 +11,23 @@ import (
 )
 
 func init() {
-	driver.Register[dialog.Chooser](&ChooserProvider{})
-	driver.Register[dialog.Driver](&FullDriverProvider{})
+	driver.Register[dialog.Chooser](&ChooserFactory{})
+	driver.Register[dialog.Driver](&FullDriverFactory{})
 }
 
-type ChooserProvider struct{}
+type ChooserFactory struct{}
 
-func (p *ChooserProvider) ID() string                                      { return "wofi" }
-func (p *ChooserProvider) Name() string                                    { return "Wofi" }
-func (p *ChooserProvider) CheckCompatibility(ctx context.Context) error    { return checkWofi(ctx) }
-func (p *ChooserProvider) New(ctx context.Context) (dialog.Chooser, error) { return &Driver{}, nil }
+func (p *ChooserFactory) ID() string                                      { return "wofi" }
+func (p *ChooserFactory) Name() string                                    { return "Wofi" }
+func (p *ChooserFactory) CheckCompatibility(ctx context.Context) error    { return checkWofi(ctx) }
+func (p *ChooserFactory) New(ctx context.Context) (dialog.Chooser, error) { return &Driver{}, nil }
 
-type FullDriverProvider struct{}
+type FullDriverFactory struct{}
 
-func (p *FullDriverProvider) ID() string                                     { return "wofi" }
-func (p *FullDriverProvider) Name() string                                   { return "Wofi" }
-func (p *FullDriverProvider) CheckCompatibility(ctx context.Context) error   { return checkWofi(ctx) }
-func (p *FullDriverProvider) New(ctx context.Context) (dialog.Driver, error) { return &Driver{}, nil }
+func (p *FullDriverFactory) ID() string                                     { return "wofi" }
+func (p *FullDriverFactory) Name() string                                   { return "Wofi" }
+func (p *FullDriverFactory) CheckCompatibility(ctx context.Context) error   { return checkWofi(ctx) }
+func (p *FullDriverFactory) New(ctx context.Context) (dialog.Driver, error) { return &Driver{}, nil }
 
 func checkWofi(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {

--- a/pkg/driver/dialog/zenity/driver.go
+++ b/pkg/driver/dialog/zenity/driver.go
@@ -11,15 +11,15 @@ import (
 )
 
 func init() {
-	driver.Register[dialog.Prompter](&PrompterProvider{})
-	driver.Register[dialog.Confirmer](&ConfirmerProvider{})
+	driver.Register[dialog.Prompter](&PrompterFactory{})
+	driver.Register[dialog.Confirmer](&ConfirmerFactory{})
 }
 
-type baseProvider struct{}
+type baseFactory struct{}
 
-func (p *baseProvider) ID() string { return "zenity" }
+func (p *baseFactory) ID() string { return "zenity" }
 
-func (p *baseProvider) CheckCompatibility(ctx context.Context) error {
+func (p *baseFactory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "DISPLAY") == "" && executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: neither DISPLAY nor WAYLAND_DISPLAY set", driver.ErrIncompatible)
 	}
@@ -29,15 +29,15 @@ func (p *baseProvider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-type PrompterProvider struct{ baseProvider }
+type PrompterFactory struct{ baseFactory }
 
-func (p *PrompterProvider) Name() string                                     { return "Zenity (Prompt)" }
-func (p *PrompterProvider) New(ctx context.Context) (dialog.Prompter, error) { return &Driver{}, nil }
+func (p *PrompterFactory) Name() string                                     { return "Zenity (Prompt)" }
+func (p *PrompterFactory) New(ctx context.Context) (dialog.Prompter, error) { return &Driver{}, nil }
 
-type ConfirmerProvider struct{ baseProvider }
+type ConfirmerFactory struct{ baseFactory }
 
-func (p *ConfirmerProvider) Name() string                                      { return "Zenity (Confirm)" }
-func (p *ConfirmerProvider) New(ctx context.Context) (dialog.Confirmer, error) { return &Driver{}, nil }
+func (p *ConfirmerFactory) Name() string                                      { return "Zenity (Confirm)" }
+func (p *ConfirmerFactory) New(ctx context.Context) (dialog.Confirmer, error) { return &Driver{}, nil }
 
 type Driver struct{}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -31,7 +31,7 @@ var (
 	ErrNotFound     = errors.New("driver not found")
 )
 
-type DriverProvider[T any] interface {
+type DriverFactory[T any] interface {
 	ID() string   // Unique slug for the driver (e.g. "wayland_swaybg")
 	Name() string // Human readable name
 	CheckCompatibility(ctx context.Context) error
@@ -41,7 +41,7 @@ type DriverProvider[T any] interface {
 type doctorEntry struct {
 	InterfaceType reflect.Type
 	InterfaceName string
-	ProviderType  reflect.Type // Type of the provider struct
+	FactoryType   reflect.Type // Type of the factory struct
 	DriverID      string
 	DriverName    string
 	Check         func(context.Context) error
@@ -100,7 +100,7 @@ func SetWeights(w map[string]map[string]int) error {
 	return nil
 }
 
-func Register[T any](provider DriverProvider[T]) {
+func Register[T any](provider DriverFactory[T]) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -124,7 +124,7 @@ func Register[T any](provider DriverProvider[T]) {
 	doctorList = append(doctorList, doctorEntry{
 		InterfaceType: t,
 		InterfaceName: getInterfaceName(t),
-		ProviderType:  reflect.TypeOf(provider),
+		FactoryType:   reflect.TypeOf(provider),
 		DriverID:      id,
 		DriverName:    provider.Name(),
 		Check:         provider.CheckCompatibility,
@@ -173,10 +173,10 @@ func Get[T any](ctx context.Context) (T, error) {
 	logger := logging.GetLogger(ctx)
 	logger.Debug("loading driver weights", "interface", ifaceName, "weights", weights, "all_weights", driverWeights)
 
-	providers := make([]DriverProvider[T], 0)
+	providers := make([]DriverFactory[T], 0)
 	if pMap, ok := Drivers[t]; ok {
 		for _, p := range pMap {
-			providers = append(providers, p.(DriverProvider[T]))
+			providers = append(providers, p.(DriverFactory[T]))
 		}
 	}
 	mu.RUnlock()
@@ -186,11 +186,11 @@ func Get[T any](ctx context.Context) (T, error) {
 		return zero, ErrNotFound
 	}
 
-	// Log all providers before sorting
-	logger.Debug("available providers", "interface", ifaceName, "count", len(providers))
+	// Log all factories before sorting
+	logger.Debug("available driver factories", "interface", ifaceName, "count", len(providers))
 	for _, p := range providers {
 		w := getConfiguredWeight(weights, p.ID())
-		logger.Debug("provider registered", "interface", ifaceName, "id", p.ID(), "name", p.Name(), "weight", w)
+		logger.Debug("factory registered", "interface", ifaceName, "id", p.ID(), "name", p.Name(), "weight", w)
 	}
 
 	// Sort providers by weight then ID
@@ -232,7 +232,7 @@ func Get[T any](ctx context.Context) (T, error) {
 type DriverStatus struct {
 	ID           string
 	Name         string
-	ProviderType reflect.Type
+	FactoryType  reflect.Type
 	Weight       int
 	Available    bool
 	Selected     bool
@@ -288,7 +288,7 @@ func Doctor(ctx context.Context) []InterfaceStatus {
 			status := DriverStatus{
 				ID:           d.DriverID,
 				Name:         d.DriverName,
-				ProviderType: d.ProviderType,
+				FactoryType:  d.FactoryType,
 				Weight:       weight,
 				Available:    err == nil,
 				Error:        err,

--- a/pkg/driver/env/native/provider.go
+++ b/pkg/driver/env/native/provider.go
@@ -10,22 +10,22 @@ import (
 	envdriver "workspaced/pkg/driver/env"
 )
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string {
+func (p *Factory) ID() string {
 	return "env_native"
 }
 
-func (p *Provider) Name() string {
+func (p *Factory) Name() string {
 	return "Native Environment"
 }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	// Always compatible
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (envdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (envdriver.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -109,5 +109,5 @@ func (d *Driver) GetEssentialPaths(ctx context.Context) []string {
 }
 
 func init() {
-	driver.Register[envdriver.Driver](&Provider{})
+	driver.Register[envdriver.Driver](&Factory{})
 }

--- a/pkg/driver/env/termux/provider.go
+++ b/pkg/driver/env/termux/provider.go
@@ -12,22 +12,22 @@ import (
 )
 
 func init() {
-	driver.Register[envdriver.Driver](&Provider{})
+	driver.Register[envdriver.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "env_termux" }
-func (p *Provider) Name() string { return "Termux Environment" }
+func (p *Factory) ID() string   { return "env_termux" }
+func (p *Factory) Name() string { return "Termux Environment" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("TERMUX_VERSION") == "" {
 		return fmt.Errorf("%w: not running in Termux", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (envdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (envdriver.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/exec/native/provider.go
+++ b/pkg/driver/exec/native/provider.go
@@ -9,22 +9,22 @@ import (
 	execdriver "workspaced/pkg/driver/exec"
 )
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string {
+func (p *Factory) ID() string {
 	return "exec_native"
 }
 
-func (p *Provider) Name() string {
+func (p *Factory) Name() string {
 	return "Native"
 }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	// Always compatible
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (execdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (execdriver.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -45,5 +45,5 @@ func (d *Driver) Which(ctx context.Context, name string) (string, error) {
 }
 
 func init() {
-	driver.Register[execdriver.Driver](&Provider{})
+	driver.Register[execdriver.Driver](&Factory{})
 }

--- a/pkg/driver/exec/termux/provider.go
+++ b/pkg/driver/exec/termux/provider.go
@@ -12,21 +12,21 @@ import (
 	"workspaced/pkg/driver"
 	envdriver "workspaced/pkg/driver/env"
 	execdriver "workspaced/pkg/driver/exec"
+	"workspaced/pkg/executil"
 	"workspaced/pkg/logging"
-	"workspaced/pkg/types"
 )
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string {
+func (p *Factory) ID() string {
 	return "exec_termux"
 }
 
-func (p *Provider) Name() string {
+func (p *Factory) Name() string {
 	return "Termux"
 }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	// TERMUX_VERSION is not guaranteed to be exported in every shell/session.
 	// Accept additional Termux markers to avoid false negatives.
 	if os.Getenv("TERMUX_VERSION") != "" {
@@ -41,7 +41,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return fmt.Errorf("%w: not running in Termux", driver.ErrIncompatible)
 }
 
-func (p *Provider) New(ctx context.Context) (execdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (execdriver.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -373,7 +373,7 @@ func (d *Driver) Which(ctx context.Context, name string) (string, error) {
 	}
 
 	path := os.Getenv("PATH")
-	if env, ok := ctx.Value(types.EnvKey).([]string); ok {
+	if env := executil.Env(ctx); env != nil {
 		for _, e := range env {
 			if after, ok0 := strings.CutPrefix(e, "PATH="); ok0 {
 				path = after
@@ -394,5 +394,5 @@ func (d *Driver) Which(ctx context.Context, name string) (string, error) {
 }
 
 func init() {
-	driver.Register[execdriver.Driver](&Provider{})
+	driver.Register[execdriver.Driver](&Factory{})
 }

--- a/pkg/driver/fetchurl/driver.go
+++ b/pkg/driver/fetchurl/driver.go
@@ -2,7 +2,13 @@ package fetchurl
 
 import (
 	"context"
+	"errors"
 	"io"
+)
+
+var (
+	ErrNoURLs          = errors.New("no URLs provided")
+	ErrNoOutputWriter  = errors.New("no output writer provided")
 )
 
 // FetchOptions configures a download operation

--- a/pkg/driver/fetchurl/fetchurl/driver.go
+++ b/pkg/driver/fetchurl/fetchurl/driver.go
@@ -15,20 +15,20 @@ import (
 )
 
 func init() {
-	driver.Register[fetchurldriver.Driver](&Provider{})
+	driver.Register[fetchurldriver.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "fetchurl" }
-func (p *Provider) Name() string { return "fetchurl" }
+func (p *Factory) ID() string   { return "fetchurl" }
+func (p *Factory) Name() string { return "fetchurl" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	// fetchurl is a pure Go library, always compatible
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (fetchurldriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (fetchurldriver.Driver, error) {
 	httpDriver, err := driver.Get[httpclient.Driver](ctx)
 	if err != nil {
 		return nil, fmt.Errorf("httpclient driver required: %w", err)
@@ -44,10 +44,10 @@ type Driver struct {
 
 func (d *Driver) Fetch(ctx context.Context, opts fetchurldriver.FetchOptions) error {
 	if len(opts.URLs) == 0 {
-		return fmt.Errorf("no URLs provided")
+		return fetchurldriver.ErrNoURLs
 	}
 	if opts.Out == nil {
-		return fmt.Errorf("no output writer provided")
+		return fetchurldriver.ErrNoOutputWriter
 	}
 
 	g := taskgroup.FromContext(ctx)

--- a/pkg/driver/httpclient/native/provider.go
+++ b/pkg/driver/httpclient/native/provider.go
@@ -17,20 +17,20 @@ import (
 )
 
 func init() {
-	driver.Register[httpclientdriver.Driver](&Provider{})
+	driver.Register[httpclientdriver.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "httpclient_native" }
-func (p *Provider) Name() string { return "Native HTTP Client" }
+func (p *Factory) ID() string   { return "httpclient_native" }
+func (p *Factory) Name() string { return "Native HTTP Client" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	// Always compatible
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (httpclientdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (httpclientdriver.Driver, error) {
 	return &Driver{
 		rootCAs: loadSystemCerts(ctx),
 	}, nil

--- a/pkg/driver/httpclient/termux/provider.go
+++ b/pkg/driver/httpclient/termux/provider.go
@@ -18,22 +18,22 @@ import (
 )
 
 func init() {
-	driver.Register[httpclientdriver.Driver](&Provider{})
+	driver.Register[httpclientdriver.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "httpclient_termux" }
-func (p *Provider) Name() string { return "Termux HTTP Client" }
+func (p *Factory) ID() string   { return "httpclient_termux" }
+func (p *Factory) Name() string { return "Termux HTTP Client" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("TERMUX_VERSION") == "" {
 		return fmt.Errorf("%w: not running in Termux", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (httpclientdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (httpclientdriver.Driver, error) {
 	return &Driver{
 		rootCAs: loadTermuxCerts(ctx),
 	}, nil

--- a/pkg/driver/media/dbus/driver.go
+++ b/pkg/driver/media/dbus/driver.go
@@ -11,15 +11,15 @@ import (
 )
 
 func init() {
-	driver.Register[media.Driver](&Provider{})
+	driver.Register[media.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "media_mpris" }
-func (p *Provider) Name() string { return "MPRIS (DBus)" }
+func (p *Factory) ID() string   { return "media_mpris" }
+func (p *Factory) Name() string { return "MPRIS (DBus)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	conn, err := dbus.SessionBus()
 	if err != nil {
 		return fmt.Errorf("%w: failed to connect to session bus: %v", driver.ErrIncompatible, err)
@@ -39,7 +39,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return fmt.Errorf("%w: no MPRIS players found on DBus", driver.ErrIncompatible)
 }
 
-func (p *Provider) New(ctx context.Context) (media.Driver, error) {
+func (p *Factory) New(ctx context.Context) (media.Driver, error) {
 	conn, err := dbus.SessionBus()
 	if err != nil {
 		return nil, err

--- a/pkg/driver/notification/dbus/driver.go
+++ b/pkg/driver/notification/dbus/driver.go
@@ -12,15 +12,15 @@ import (
 )
 
 func init() {
-	driver.Register[notification.Driver](&Provider{})
+	driver.Register[notification.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "notification_dbus" }
-func (p *Provider) Name() string { return "DBus" }
+func (p *Factory) ID() string   { return "notification_dbus" }
+func (p *Factory) Name() string { return "DBus" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	conn, err := dbus.SessionBus()
 	if err != nil {
 		return fmt.Errorf("%w: failed to connect to session bus: %v", driver.ErrIncompatible, err)
@@ -45,7 +45,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (notification.Driver, error) {
+func (p *Factory) New(ctx context.Context) (notification.Driver, error) {
 	conn, err := dbus.SessionBus()
 	if err != nil {
 		return nil, err

--- a/pkg/driver/notification/notify_send/driver.go
+++ b/pkg/driver/notification/notify_send/driver.go
@@ -9,22 +9,22 @@ import (
 )
 
 func init() {
-	driver.Register[notification.Driver](&Provider{})
+	driver.Register[notification.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "notification_notify_send" }
-func (p *Provider) Name() string { return "notify-send" }
+func (p *Factory) ID() string   { return "notification_notify_send" }
+func (p *Factory) Name() string { return "notify-send" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "notify-send") {
 		return fmt.Errorf("%w: notify-send not found", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (notification.Driver, error) {
+func (p *Factory) New(ctx context.Context) (notification.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/notification/termux/driver.go
+++ b/pkg/driver/notification/termux/driver.go
@@ -9,22 +9,22 @@ import (
 )
 
 func init() {
-	driver.Register[notification.Driver](&Provider{})
+	driver.Register[notification.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "notification_termux" }
-func (p *Provider) Name() string { return "Termux" }
+func (p *Factory) ID() string   { return "notification_termux" }
+func (p *Factory) Name() string { return "Termux" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "termux-notification") {
 		return fmt.Errorf("%w: termux-notification not found", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (notification.Driver, error) {
+func (p *Factory) New(ctx context.Context) (notification.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/opener/termux/driver.go
+++ b/pkg/driver/opener/termux/driver.go
@@ -10,15 +10,15 @@ import (
 )
 
 func init() {
-	driver.Register[opener.Driver](&Provider{})
+	driver.Register[opener.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "opener_termux" }
-func (p *Provider) Name() string { return "termux-open" }
+func (p *Factory) ID() string   { return "opener_termux" }
+func (p *Factory) Name() string { return "termux-open" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("TERMUX_VERSION") == "" {
 		return fmt.Errorf("%w: not running in Termux", driver.ErrIncompatible)
 	}
@@ -28,7 +28,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (opener.Driver, error) {
+func (p *Factory) New(ctx context.Context) (opener.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/opener/xdg/driver.go
+++ b/pkg/driver/opener/xdg/driver.go
@@ -10,15 +10,15 @@ import (
 )
 
 func init() {
-	driver.Register[opener.Driver](&Provider{})
+	driver.Register[opener.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "opener_xdg" }
-func (p *Provider) Name() string { return "xdg-open" }
+func (p *Factory) ID() string   { return "opener_xdg" }
+func (p *Factory) Name() string { return "xdg-open" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "DISPLAY") == "" && executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: neither DISPLAY nor WAYLAND_DISPLAY set", driver.ErrIncompatible)
 	}
@@ -28,7 +28,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (opener.Driver, error) {
+func (p *Factory) New(ctx context.Context) (opener.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/power/systemd/driver.go
+++ b/pkg/driver/power/systemd/driver.go
@@ -9,15 +9,15 @@ import (
 )
 
 func init() {
-	driver.Register[power.Driver](&Provider{})
+	driver.Register[power.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "power_systemd" }
-func (p *Provider) Name() string { return "Systemd" }
+func (p *Factory) ID() string   { return "power_systemd" }
+func (p *Factory) Name() string { return "Systemd" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "loginctl") {
 		return fmt.Errorf("%w: loginctl not found", driver.ErrIncompatible)
 	}
@@ -27,7 +27,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (power.Driver, error) {
+func (p *Factory) New(ctx context.Context) (power.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/power/termux/driver.go
+++ b/pkg/driver/power/termux/driver.go
@@ -11,22 +11,22 @@ import (
 )
 
 func init() {
-	driver.Register[power.Driver](&Provider{})
+	driver.Register[power.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "power_termux" }
-func (p *Provider) Name() string { return "Termux" }
+func (p *Factory) ID() string   { return "power_termux" }
+func (p *Factory) Name() string { return "Termux" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("TERMUX_VERSION") == "" {
 		return fmt.Errorf("%w: not running in Termux", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (power.Driver, error) {
+func (p *Factory) New(ctx context.Context) (power.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/screen/sway/driver.go
+++ b/pkg/driver/screen/sway/driver.go
@@ -13,15 +13,15 @@ import (
 )
 
 func init() {
-	driver.Register[screen.Driver](&Provider{})
+	driver.Register[screen.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "screen_sway" }
-func (p *Provider) Name() string { return "Wayland (sway)" }
+func (p *Factory) ID() string   { return "screen_sway" }
+func (p *Factory) Name() string { return "Wayland (sway)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: WAYLAND_DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -31,7 +31,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (screen.Driver, error) {
+func (p *Factory) New(ctx context.Context) (screen.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/screen/x11/driver.go
+++ b/pkg/driver/screen/x11/driver.go
@@ -3,35 +3,26 @@ package x11
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"workspaced/pkg/api"
 	"workspaced/pkg/driver"
 	execdriver "workspaced/pkg/driver/exec"
 	"workspaced/pkg/driver/screen"
 	"workspaced/pkg/env"
-	"workspaced/pkg/types"
+	"workspaced/pkg/executil"
 )
 
 func init() {
-	driver.Register[screen.Driver](&Provider{})
+	driver.Register[screen.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "screen_x11" }
-func (p *Provider) Name() string { return "X11" }
+func (p *Factory) ID() string   { return "screen_x11" }
+func (p *Factory) Name() string { return "X11" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
-	display := os.Getenv("DISPLAY")
-	if env, ok := ctx.Value(types.EnvKey).([]string); ok {
-		for _, e := range env {
-			if after, ok0 := strings.CutPrefix(e, "DISPLAY="); ok0 {
-				display = after
-				break
-			}
-		}
-	}
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
+	display := executil.GetEnv(ctx, "DISPLAY")
 
 	if display == "" {
 		return fmt.Errorf("%w: DISPLAY not set", driver.ErrIncompatible)
@@ -45,7 +36,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (screen.Driver, error) {
+func (p *Factory) New(ctx context.Context) (screen.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/screenshot/driver.go
+++ b/pkg/driver/screenshot/driver.go
@@ -2,8 +2,14 @@ package screenshot
 
 import (
 	"context"
+	"errors"
 	"image"
 	api "workspaced/pkg/driver/wm"
+)
+
+var (
+	ErrSelectionToolNotFound = errors.New("selection tool not found")
+	ErrEmptySelection        = errors.New("empty selection")
 )
 
 type TargetType int

--- a/pkg/driver/screenshot/grim/driver.go
+++ b/pkg/driver/screenshot/grim/driver.go
@@ -16,15 +16,15 @@ import (
 )
 
 func init() {
-	driver.Register[screenshot.Driver](&Provider{})
+	driver.Register[screenshot.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "screenshot_grim" }
-func (p *Provider) Name() string { return "Grim (Wayland)" }
+func (p *Factory) ID() string   { return "screenshot_grim" }
+func (p *Factory) Name() string { return "Grim (Wayland)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: WAYLAND_DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -34,7 +34,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (screenshot.Driver, error) {
+func (p *Factory) New(ctx context.Context) (screenshot.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -42,7 +42,7 @@ type Driver struct{}
 
 func (d *Driver) SelectArea(ctx context.Context) (*api.Rect, error) {
 	if !execdriver.IsBinaryAvailable(ctx, "slurp") {
-		return nil, fmt.Errorf("slurp not found for selection")
+		return nil, screenshot.ErrSelectionToolNotFound
 	}
 	out, err := execdriver.MustRun(ctx, "slurp").Output()
 	if err != nil {
@@ -50,7 +50,7 @@ func (d *Driver) SelectArea(ctx context.Context) (*api.Rect, error) {
 	}
 	raw := strings.TrimSpace(string(out))
 	if raw == "" {
-		return nil, fmt.Errorf("empty selection")
+		return nil, screenshot.ErrEmptySelection
 	}
 	// slurp output: "x,y wxh"
 	parts := strings.FieldsFunc(raw, func(r rune) bool {

--- a/pkg/driver/screenshot/maim/driver.go
+++ b/pkg/driver/screenshot/maim/driver.go
@@ -16,15 +16,15 @@ import (
 )
 
 func init() {
-	driver.Register[screenshot.Driver](&Provider{})
+	driver.Register[screenshot.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "screenshot_maim" }
-func (p *Provider) Name() string { return "Maim (X11)" }
+func (p *Factory) ID() string   { return "screenshot_maim" }
+func (p *Factory) Name() string { return "Maim (X11)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "DISPLAY") == "" {
 		return fmt.Errorf("%w: DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -34,7 +34,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (screenshot.Driver, error) {
+func (p *Factory) New(ctx context.Context) (screenshot.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -45,7 +45,7 @@ func (d *Driver) SelectArea(ctx context.Context) (*api.Rect, error) {
 	// maim -g $(slop) ... is common.
 	// We can run slop directly to get the geometry.
 	if !execdriver.IsBinaryAvailable(ctx, "slop") {
-		return nil, fmt.Errorf("slop not found for selection")
+		return nil, screenshot.ErrSelectionToolNotFound
 	}
 	out, err := execdriver.MustRun(ctx, "slop", "-f", "%x %y %w %h").Output()
 	if err != nil {

--- a/pkg/driver/shell/bash/provider.go
+++ b/pkg/driver/shell/bash/provider.go
@@ -7,22 +7,22 @@ import (
 	shelldriver "workspaced/pkg/driver/shell"
 )
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string {
+func (p *Factory) ID() string {
 	return "shell_bash"
 }
 
-func (p *Provider) Name() string {
+func (p *Factory) Name() string {
 	return "Bash"
 }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	_, err := execdriver.Which(ctx, "bash")
 	return err
 }
 
-func (p *Provider) New(ctx context.Context) (shelldriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (shelldriver.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -49,5 +49,5 @@ func (d *Driver) Path(ctx context.Context) (string, error) {
 }
 
 func init() {
-	driver.Register[shelldriver.Driver](&Provider{})
+	driver.Register[shelldriver.Driver](&Factory{})
 }

--- a/pkg/driver/shell/sh/provider.go
+++ b/pkg/driver/shell/sh/provider.go
@@ -7,22 +7,22 @@ import (
 	shelldriver "workspaced/pkg/driver/shell"
 )
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string {
+func (p *Factory) ID() string {
 	return "shell_sh"
 }
 
-func (p *Provider) Name() string {
+func (p *Factory) Name() string {
 	return "POSIX sh"
 }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	_, err := execdriver.Which(ctx, "sh")
 	return err
 }
 
-func (p *Provider) New(ctx context.Context) (shelldriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (shelldriver.Driver, error) {
 	return &Driver{}, nil
 }
 
@@ -49,5 +49,5 @@ func (d *Driver) Path(ctx context.Context) (string, error) {
 }
 
 func init() {
-	driver.Register[shelldriver.Driver](&Provider{})
+	driver.Register[shelldriver.Driver](&Factory{})
 }

--- a/pkg/driver/shim/bash/driver.go
+++ b/pkg/driver/shim/bash/driver.go
@@ -11,17 +11,17 @@ import (
 	shimdriver "workspaced/pkg/driver/shim"
 )
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string {
+func (p *Factory) ID() string {
 	return "shim_bash"
 }
 
-func (p *Provider) Name() string {
+func (p *Factory) Name() string {
 	return "Bash Shim"
 }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	_, err := execdriver.Which(ctx, "bash")
 	return err
 }
@@ -38,7 +38,7 @@ func GetShell(ctx context.Context) string {
 	return bashPath
 }
 
-func (p *Provider) New(ctx context.Context) (shimdriver.Driver, error) {
+func (p *Factory) New(ctx context.Context) (shimdriver.Driver, error) {
 	bashPath := GetShell(ctx)
 	return &Driver{bashPath: bashPath}, nil
 }
@@ -50,7 +50,7 @@ type Driver struct {
 // GenerateContent creates the shim script content
 func (d *Driver) GenerateContent(command []string) (string, error) {
 	if len(command) == 0 {
-		return "", fmt.Errorf("command cannot be empty")
+		return "", shimdriver.ErrEmptyCommand
 	}
 
 	// Escape command for shell
@@ -92,5 +92,5 @@ func (d *Driver) Generate(ctx context.Context, path string, command []string) er
 }
 
 func init() {
-	driver.Register[shimdriver.Driver](&Provider{})
+	driver.Register[shimdriver.Driver](&Factory{})
 }

--- a/pkg/driver/shim/driver.go
+++ b/pkg/driver/shim/driver.go
@@ -2,7 +2,12 @@ package shim
 
 import (
 	"context"
+	"errors"
 	"workspaced/pkg/driver"
+)
+
+var (
+	ErrEmptyCommand = errors.New("command cannot be empty")
 )
 
 // Driver provides shim script generation capabilities

--- a/pkg/driver/svgraster/resvg/driver.go
+++ b/pkg/driver/svgraster/resvg/driver.go
@@ -78,20 +78,20 @@ func (d *Driver) RasterizeSVG(ctx context.Context, svg string, width int, height
 	return img, nil
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p Provider) ID() string { return "resvg" }
-func (p Provider) Name() string {
+func (p Factory) ID() string { return "resvg" }
+func (p Factory) Name() string {
 	return "resvg"
 }
-func (p Provider) CheckCompatibility(ctx context.Context) error {
+func (p Factory) CheckCompatibility(ctx context.Context) error {
 	// resvg is installed on demand via the tool registry (catalog).
 	return nil
 }
-func (p Provider) New(ctx context.Context) (svgraster.Driver, error) {
+func (p Factory) New(ctx context.Context) (svgraster.Driver, error) {
 	return &Driver{}, nil
 }
 
 func init() {
-	driver.Register[svgraster.Driver](Provider{})
+	driver.Register[svgraster.Driver](Factory{})
 }

--- a/pkg/driver/terminal/alacritty/driver.go
+++ b/pkg/driver/terminal/alacritty/driver.go
@@ -9,22 +9,22 @@ import (
 )
 
 func init() {
-	driver.Register[terminal.Driver](&Provider{})
+	driver.Register[terminal.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "terminal_alacritty" }
-func (p *Provider) Name() string { return "Alacritty" }
+func (p *Factory) ID() string   { return "terminal_alacritty" }
+func (p *Factory) Name() string { return "Alacritty" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "alacritty") {
 		return fmt.Errorf("%w: alacritty not found", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (terminal.Driver, error) {
+func (p *Factory) New(ctx context.Context) (terminal.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/terminal/foot/driver.go
+++ b/pkg/driver/terminal/foot/driver.go
@@ -10,15 +10,15 @@ import (
 )
 
 func init() {
-	driver.Register[terminal.Driver](&Provider{})
+	driver.Register[terminal.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "terminal_foot" }
-func (p *Provider) Name() string { return "Foot" }
+func (p *Factory) ID() string   { return "terminal_foot" }
+func (p *Factory) Name() string { return "Foot" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: foot requires WAYLAND_DISPLAY", driver.ErrIncompatible)
 	}
@@ -28,7 +28,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (terminal.Driver, error) {
+func (p *Factory) New(ctx context.Context) (terminal.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/terminal/kitty/driver.go
+++ b/pkg/driver/terminal/kitty/driver.go
@@ -9,22 +9,22 @@ import (
 )
 
 func init() {
-	driver.Register[terminal.Driver](&Provider{})
+	driver.Register[terminal.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "terminal_kitty" }
-func (p *Provider) Name() string { return "Kitty" }
+func (p *Factory) ID() string   { return "terminal_kitty" }
+func (p *Factory) Name() string { return "Kitty" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if !execdriver.IsBinaryAvailable(ctx, "kitty") {
 		return fmt.Errorf("%w: kitty not found", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (terminal.Driver, error) {
+func (p *Factory) New(ctx context.Context) (terminal.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/terminal/termux/driver.go
+++ b/pkg/driver/terminal/termux/driver.go
@@ -11,22 +11,22 @@ import (
 )
 
 func init() {
-	driver.Register[terminal.Driver](&Provider{})
+	driver.Register[terminal.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "terminal_termux" }
-func (p *Provider) Name() string { return "Termux" }
+func (p *Factory) ID() string   { return "terminal_termux" }
+func (p *Factory) Name() string { return "Termux" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("TERMUX_VERSION") == "" {
 		return fmt.Errorf("%w: not running in Termux", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (terminal.Driver, error) {
+func (p *Factory) New(ctx context.Context) (terminal.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/tray/dbus/driver.go
+++ b/pkg/driver/tray/dbus/driver.go
@@ -14,22 +14,22 @@ import (
 )
 
 func init() {
-	driver.Register[tray.Driver](&Provider{})
+	driver.Register[tray.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "tray_dbus" }
-func (p *Provider) Name() string { return "DBus" }
+func (p *Factory) ID() string   { return "tray_dbus" }
+func (p *Factory) Name() string { return "DBus" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
 		return fmt.Errorf("%w: DBUS_SESSION_BUS_ADDRESS not set", driver.ErrIncompatible)
 	}
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (tray.Driver, error) {
+func (p *Factory) New(ctx context.Context) (tray.Driver, error) {
 	return NewDriver(), nil
 }
 
@@ -88,7 +88,7 @@ func (d *Driver) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to request name: %w", err)
 	}
 	if reply != dbus.RequestNameReplyPrimaryOwner {
-		return fmt.Errorf("name already taken")
+		return tray.ErrNameTaken
 	}
 
 	// Emit NewMenu signal to let watcher know we have a menu

--- a/pkg/driver/tray/driver.go
+++ b/pkg/driver/tray/driver.go
@@ -2,7 +2,12 @@ package tray
 
 import (
 	"context"
+	"errors"
 	"image"
+)
+
+var (
+	ErrNameTaken = errors.New("tray name already taken")
 )
 
 // MenuItem represents an item in the tray menu.

--- a/pkg/driver/wallpaper/feh/driver.go
+++ b/pkg/driver/wallpaper/feh/driver.go
@@ -10,15 +10,15 @@ import (
 )
 
 func init() {
-	driver.Register[wallpaper.Driver](&Provider{})
+	driver.Register[wallpaper.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "x11_feh" }
-func (p *Provider) Name() string { return "X11 (feh)" }
+func (p *Factory) ID() string   { return "x11_feh" }
+func (p *Factory) Name() string { return "X11 (feh)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if os.Getenv("DISPLAY") == "" {
 		return fmt.Errorf("%w: DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -31,7 +31,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (wallpaper.Driver, error) {
+func (p *Factory) New(ctx context.Context) (wallpaper.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/wallpaper/swaybg/driver.go
+++ b/pkg/driver/wallpaper/swaybg/driver.go
@@ -10,15 +10,15 @@ import (
 )
 
 func init() {
-	driver.Register[wallpaper.Driver](&Provider{})
+	driver.Register[wallpaper.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "wayland_swaybg" }
-func (p *Provider) Name() string { return "Wayland (swaybg)" }
+func (p *Factory) ID() string   { return "wayland_swaybg" }
+func (p *Factory) Name() string { return "Wayland (swaybg)" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: WAYLAND_DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -31,7 +31,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (wallpaper.Driver, error) {
+func (p *Factory) New(ctx context.Context) (wallpaper.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/wm/facade.go
+++ b/pkg/driver/wm/facade.go
@@ -16,7 +16,7 @@ import (
 
 var wmMu sync.Mutex
 
-// switchToWorkspace é a implementação interna sem lock para evitar deadlock
+// switchToWorkspace is the internal lock-free implementation to avoid deadlocks.
 func switchToWorkspace(ctx context.Context, ws string, move bool) error {
 	d, err := driver.Get[Driver](ctx)
 	if err != nil {
@@ -136,13 +136,13 @@ func RotateWorkspaces(ctx context.Context) error {
 		toScreen := screens[i]
 		ws := workspaceScreens[fromScreen]
 
-		// Move o workspace para o novo monitor.
+		// Move the workspace to the new output.
 		if err := d.MoveWorkspaceToOutput(ctx, ws, toScreen); err != nil {
 			logging.ReportError(ctx, err)
 		}
 	}
 
-	// Restaura o foco original
+	// Restore the original focus
 	if focusedWorkspace != "" {
 		if err := switchToWorkspace(ctx, focusedWorkspace, false); err != nil {
 			logging.ReportError(ctx, err)

--- a/pkg/driver/wm/hyprland/driver.go
+++ b/pkg/driver/wm/hyprland/driver.go
@@ -12,15 +12,15 @@ import (
 )
 
 func init() {
-	driver.Register[api.Driver](&Provider{})
+	driver.Register[api.Driver](&Factory{})
 }
 
-type Provider struct{}
+type Factory struct{}
 
-func (p *Provider) ID() string   { return "wm_hyprland" }
-func (p *Provider) Name() string { return "Hyprland" }
+func (p *Factory) ID() string   { return "wm_hyprland" }
+func (p *Factory) Name() string { return "Hyprland" }
 
-func (p *Provider) CheckCompatibility(ctx context.Context) error {
+func (p *Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "HYPRLAND_INSTANCE_SIGNATURE") == "" {
 		return fmt.Errorf("%w: HYPRLAND_INSTANCE_SIGNATURE not set", driver.ErrIncompatible)
 	}
@@ -30,7 +30,7 @@ func (p *Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) New(ctx context.Context) (api.Driver, error) {
+func (p *Factory) New(ctx context.Context) (api.Driver, error) {
 	return &Driver{}, nil
 }
 

--- a/pkg/driver/wm/i3ipc/driver.go
+++ b/pkg/driver/wm/i3ipc/driver.go
@@ -12,15 +12,15 @@ import (
 )
 
 func init() {
-	driver.Register[api.Driver](&SwayProvider{})
-	driver.Register[api.Driver](&I3Provider{})
+	driver.Register[api.Driver](&SwayFactory{})
+	driver.Register[api.Driver](&I3Factory{})
 }
 
-type SwayProvider struct{}
+type SwayFactory struct{}
 
-func (p *SwayProvider) ID() string   { return "screen_wayland_sway" }
-func (p *SwayProvider) Name() string { return "Sway" }
-func (p *SwayProvider) CheckCompatibility(ctx context.Context) error {
+func (p *SwayFactory) ID() string   { return "screen_wayland_sway" }
+func (p *SwayFactory) Name() string { return "Sway" }
+func (p *SwayFactory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "WAYLAND_DISPLAY") == "" {
 		return fmt.Errorf("%w: WAYLAND_DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -30,15 +30,15 @@ func (p *SwayProvider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *SwayProvider) New(ctx context.Context) (api.Driver, error) {
+func (p *SwayFactory) New(ctx context.Context) (api.Driver, error) {
 	return &Driver{Binary: "swaymsg"}, nil
 }
 
-type I3Provider struct{}
+type I3Factory struct{}
 
-func (p *I3Provider) ID() string   { return "screen_x11_i3" }
-func (p *I3Provider) Name() string { return "i3" }
-func (p *I3Provider) CheckCompatibility(ctx context.Context) error {
+func (p *I3Factory) ID() string   { return "screen_x11_i3" }
+func (p *I3Factory) Name() string { return "i3" }
+func (p *I3Factory) CheckCompatibility(ctx context.Context) error {
 	if executil.GetEnv(ctx, "DISPLAY") == "" {
 		return fmt.Errorf("%w: DISPLAY not set", driver.ErrIncompatible)
 	}
@@ -48,7 +48,7 @@ func (p *I3Provider) CheckCompatibility(ctx context.Context) error {
 	return nil
 }
 
-func (p *I3Provider) New(ctx context.Context) (api.Driver, error) {
+func (p *I3Factory) New(ctx context.Context) (api.Driver, error) {
 	return &Driver{Binary: "i3-msg"}, nil
 }
 

--- a/pkg/executil/executil.go
+++ b/pkg/executil/executil.go
@@ -10,23 +10,59 @@ import (
 	"strings"
 	"time"
 	"workspaced/pkg/logging"
-	"workspaced/pkg/types"
 )
+
+type stdoutKey struct{}
+type stderrKey struct{}
+type envKey struct{}
+
+// WithStdout returns a context carrying an io.Writer for standard output.
+func WithStdout(ctx context.Context, w io.Writer) context.Context {
+	return context.WithValue(ctx, stdoutKey{}, w)
+}
+
+// Stdout retrieves the stdout writer from the context, or nil if not set.
+func Stdout(ctx context.Context) io.Writer {
+	w, _ := ctx.Value(stdoutKey{}).(io.Writer)
+	return w
+}
+
+// WithStderr returns a context carrying an io.Writer for standard error.
+func WithStderr(ctx context.Context, w io.Writer) context.Context {
+	return context.WithValue(ctx, stderrKey{}, w)
+}
+
+// Stderr retrieves the stderr writer from the context, or nil if not set.
+func Stderr(ctx context.Context) io.Writer {
+	w, _ := ctx.Value(stderrKey{}).(io.Writer)
+	return w
+}
+
+// WithEnv returns a context carrying environment variables as a slice of "KEY=VALUE" strings.
+func WithEnv(ctx context.Context, env []string) context.Context {
+	return context.WithValue(ctx, envKey{}, env)
+}
+
+// Env retrieves the environment variable slice from the context, or nil if not set.
+func Env(ctx context.Context) []string {
+	env, _ := ctx.Value(envKey{}).([]string)
+	return env
+}
 
 // InheritContextWriters configures the command's Stdout and Stderr to write to the writers
 // stored in the context, allowing output capture or redirection.
 func InheritContextWriters(ctx context.Context, cmd *exec.Cmd) {
-	if stdout, ok := ctx.Value(types.StdoutKey).(io.Writer); ok {
+	if stdout := Stdout(ctx); stdout != nil {
 		cmd.Stdout = stdout
 	}
-	if stderr, ok := ctx.Value(types.StderrKey).(io.Writer); ok {
+	if stderr := Stderr(ctx); stderr != nil {
 		cmd.Stderr = stderr
 	}
 }
 
 // GetEnv retrieves an environment variable from the context or the system.
 func GetEnv(ctx context.Context, key string) string {
-	if env, ok := ctx.Value(types.EnvKey).([]string); ok {
+	if env := Env(ctx); env != nil {
 		for _, e := range env {
 			if strings.HasPrefix(e, key+"=") {
 				return e[len(key)+1:]

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -47,7 +47,7 @@ func QuickSync(ctx context.Context) error {
 	}
 
 	n := &notification.Notification{
-		Title: "Sincronização Git",
+		Title: "Git Sync",
 		Icon:  "git",
 	}
 
@@ -58,7 +58,7 @@ func QuickSync(ctx context.Context) error {
 		}
 
 		repoPath := filepath.Join(repoDir, repoName)
-		n.Message = fmt.Sprintf("Sincronizando %s...", repoName)
+		n.Message = fmt.Sprintf("Syncing %s...", repoName)
 		n.Progress = float64(i) / float64(total)
 		logging.ReportError(ctx, notification.Notify(ctx, n))
 
@@ -66,8 +66,8 @@ func QuickSync(ctx context.Context) error {
 		if err := SyncRepo(ctx, repoPath); err != nil {
 			logger.Error("failed to sync repo", "repo", repoName, "error", err)
 			errN := &notification.Notification{
-				Title:   "Sincronização Falhou",
-				Message: fmt.Sprintf("Conflito ou erro em %s. Intervenção manual necessária.", repoName),
+				Title:   "Sync Failed",
+				Message: fmt.Sprintf("Conflict or error in %s. Manual intervention required.", repoName),
 				Urgency: "critical",
 				Icon:    "dialog-warning",
 			}
@@ -75,7 +75,7 @@ func QuickSync(ctx context.Context) error {
 		}
 	}
 
-	n.Message = "Sincronização concluída."
+	n.Message = "Sync completed."
 	n.Progress = 1.0
 	logging.ReportError(ctx, notification.Notify(ctx, n))
 

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -22,6 +23,8 @@ import (
 	"workspaced/pkg/logging"
 	"workspaced/pkg/taskgroup"
 )
+
+var ErrBadHTTPStatus = errors.New("unexpected HTTP status")
 
 func GetIconPath(ctx context.Context, url string) (string, error) {
 	configDir, err := env.GetConfigDir(ctx)
@@ -73,7 +76,7 @@ func GetIconPath(ctx context.Context, url string) (string, error) {
 		defer logging.Close(ctx, resp.Body)
 
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("bad status: %s", resp.Status)
+			return fmt.Errorf("%w: %s", ErrBadHTTPStatus, resp.Status)
 		}
 
 		img, _, err := image.Decode(resp.Body)

--- a/pkg/icons/theme_generate_engine.go
+++ b/pkg/icons/theme_generate_engine.go
@@ -3,6 +3,7 @@ package icons
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	imagedraw "image/draw"
@@ -26,6 +27,17 @@ import (
 	"workspaced/pkg/taskgroup"
 
 	xdraw "golang.org/x/image/draw"
+)
+
+var (
+	ErrNoValidSizes        = errors.New("no valid sizes provided")
+	ErrBase16NotConfigured = errors.New("module base16 is not configured")
+	ErrInvalidBase16Config = errors.New("invalid modules.base16 config")
+	ErrBase16MissingColors = errors.New("modules.base16 must include at least base00/base05/base0D")
+	ErrInvalidSize         = errors.New("invalid icon size")
+	ErrInvalidJobs         = errors.New("invalid jobs value")
+	ErrInvalidReplaceRule  = errors.New("invalid color replace rule")
+	ErrNoSVGFiles          = errors.New("no .svg or .svg.tmpl files found")
 )
 
 var sizeDirPrefixRe = regexp.MustCompile(`^\d+x\d+$`)
@@ -65,7 +77,7 @@ func runThemeGenerateEngine(ctx context.Context, opts ThemeGenerateOptions, inpu
 		return err
 	}
 	if len(paths) == 0 {
-		return fmt.Errorf("no .svg or .svg.tmpl files found in %s", inputDir)
+		return fmt.Errorf("%w: %s", ErrNoSVGFiles, inputDir)
 	}
 
 	maxSize := 0
@@ -289,12 +301,12 @@ func parseSizes(raw string) ([]int, error) {
 		}
 		n, err := strconv.Atoi(p)
 		if err != nil || n <= 0 {
-			return nil, fmt.Errorf("invalid size %q", p)
+			return nil, fmt.Errorf("%w: %q", ErrInvalidSize, p)
 		}
 		out = append(out, n)
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("no valid sizes provided")
+		return nil, ErrNoValidSizes
 	}
 	sort.Ints(out)
 	return out, nil
@@ -314,7 +326,7 @@ func resolveJobs(raw string) (int, error) {
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil || n < 1 {
-		return 0, fmt.Errorf("invalid --jobs %q (use integer >= 1 or 'auto')", raw)
+		return 0, fmt.Errorf("%w: %q (use integer >= 1 or 'auto')", ErrInvalidJobs, raw)
 	}
 	return n, nil
 }
@@ -326,11 +338,11 @@ func loadBase16Colors(ctx context.Context) (map[string]string, error) {
 	}
 	entry, err := cfg.ModuleEntry("base16")
 	if err != nil {
-		return nil, fmt.Errorf("module base16 is not configured")
+		return nil, ErrBase16NotConfigured
 	}
 	m := entry.Config
 	if m == nil {
-		return nil, fmt.Errorf("invalid modules.base16 config")
+		return nil, ErrInvalidBase16Config
 	}
 
 	out := map[string]string{}
@@ -344,7 +356,7 @@ func loadBase16Colors(ctx context.Context) (map[string]string, error) {
 		out[strings.ToUpper(k)] = s
 	}
 	if out["base00"] == "" || out["base05"] == "" || out["base0D"] == "" {
-		return nil, fmt.Errorf("modules.base16 must include at least base00/base05/base0D")
+		return nil, ErrBase16MissingColors
 	}
 	return out, nil
 }
@@ -354,12 +366,12 @@ func parseColorReplacements(rules []string) (map[string]string, error) {
 	for _, r := range rules {
 		pair := strings.SplitN(r, "=", 2)
 		if len(pair) != 2 {
-			return nil, fmt.Errorf("invalid --replace rule %q (expected old=new)", r)
+			return nil, fmt.Errorf("%w: %q (expected old=new)", ErrInvalidReplaceRule, r)
 		}
 		oldC := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(pair[0]), "#"))
 		newC := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(pair[1]), "#"))
 		if len(oldC) != 6 || len(newC) != 6 {
-			return nil, fmt.Errorf("invalid --replace rule %q (expected 6-digit hex)", r)
+			return nil, fmt.Errorf("%w: %q (expected 6-digit hex)", ErrInvalidReplaceRule, r)
 		}
 		out[oldC] = newC
 	}

--- a/pkg/icons/theme_generator.go
+++ b/pkg/icons/theme_generator.go
@@ -2,6 +2,7 @@ package icons
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -12,6 +13,8 @@ import (
 
 	"workspaced/pkg/env"
 )
+
+var ErrIconSourceDirNotFound = errors.New("icon source directory not found")
 
 type ThemeGenerateOptions struct {
 	InputDir       string
@@ -72,7 +75,7 @@ func RunThemeGenerate(ctx context.Context, opts ThemeGenerateOptions) error {
 	outputDir := env.ExpandPath(opts.OutputDir)
 
 	if _, err := os.Stat(inputDir); err != nil {
-		return fmt.Errorf("icon source dir not found: %s", inputDir)
+		return fmt.Errorf("%w: %s", ErrIconSourceDirNotFound, inputDir)
 	}
 
 	if opts.UseCache {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -8,29 +8,30 @@ import (
 	"workspaced/pkg/types"
 )
 
+type loggerKey struct{}
+
 // GetLogger retrieves the logger instance from the context.
-// It panics if no logger has been injected into the context via ContextWithLogger
-// (or equivalent direct value set for types.LoggerKey). This enforces that all
-// logging goes through a properly provided ctx (never a bare context.Background
-// or context without a logger).
+// It panics if no logger has been injected into the context via ContextWithLogger.
+// This enforces that all logging goes through a properly provided ctx
+// (never a bare context.Background or context without a logger).
 func GetLogger(ctx context.Context) *slog.Logger {
 	if ctx == nil {
 		panic("GetLogger called with nil context")
 	}
-	if logger, ok := ctx.Value(types.LoggerKey).(*slog.Logger); ok && logger != nil {
+	if logger, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok && logger != nil {
 		return logger
 	}
-	panic("no logger present in context (types.LoggerKey); call ContextWithLogger (or equivalent) on a root ctx before any GetLogger / ReportError / Close / RunCleanup etc. See cmd/workspaced/root.go for bootstrap pattern.")
+	panic("no logger present in context; call ContextWithLogger on a root ctx before any GetLogger / ReportError / Close / RunCleanup etc. See cmd/workspaced/root.go for bootstrap pattern.")
 }
 
-// ContextWithLogger returns a context that carries the given *slog.Logger
-// under the standard LoggerKey. This is the way to inject a (possibly
-// derived) logger so that GetLogger and downstream code can retrieve it.
+// ContextWithLogger returns a context that carries the given *slog.Logger.
+// This is the way to inject a (possibly derived) logger so that GetLogger
+// and downstream code can retrieve it.
 func ContextWithLogger(ctx context.Context, l *slog.Logger) context.Context {
 	if l == nil {
 		return ctx
 	}
-	return context.WithValue(ctx, types.LoggerKey, l)
+	return context.WithValue(ctx, loggerKey{}, l)
 }
 
 // NewRootContext returns a fresh root context (derived from context.Background)
@@ -49,7 +50,7 @@ func ContextHasLogger(ctx context.Context) bool {
 	if ctx == nil {
 		return false
 	}
-	l, ok := ctx.Value(types.LoggerKey).(*slog.Logger)
+	l, ok := ctx.Value(loggerKey{}).(*slog.Logger)
 	return ok && l != nil
 }
 

--- a/pkg/miseutil/mise.go
+++ b/pkg/miseutil/mise.go
@@ -3,6 +3,7 @@ package miseutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,18 @@ import (
 	execdriver "workspaced/pkg/driver/exec"
 	"workspaced/pkg/driver/httpclient"
 	"workspaced/pkg/logging"
+	"workspaced/pkg/tool"
+)
+
+var (
+	// ErrMiseInstallPathUnknown is returned when the mise install path cannot be determined.
+	ErrMiseInstallPathUnknown = errors.New("could not determine mise install path")
+	// ErrBinaryNotFound is returned when a binary is not found in the mise install tree.
+	ErrBinaryNotFound = errors.New("binary not found")
+	// ErrMiseInstallFailed is returned when mise installation fails.
+	ErrMiseInstallFailed = errors.New("mise installation failed")
+	// ErrHTTPDownloadFailed is errors.New("HTTP download failed")
+	ErrHTTPDownloadFailed = errors.New("HTTP download failed")
 )
 
 func GetPath() string {
@@ -31,7 +44,7 @@ func GetPath() string {
 func Ensure(ctx context.Context) (string, error) {
 	misePath := GetPath()
 	if misePath == "" {
-		return "", fmt.Errorf("could not determine mise install path")
+		return "", ErrMiseInstallPathUnknown
 	}
 
 	if _, err := os.Stat(misePath); err == nil {
@@ -94,20 +107,11 @@ func ResolveBinPath(ctx context.Context, binName, toolSpec string) (string, erro
 		return "", err
 	}
 
-	candidates := []string{
-		filepath.Join(root, "bin", binName),
-		filepath.Join(root, "bin", binName+".exe"),
-		filepath.Join(root, binName),
-		filepath.Join(root, binName+".exe"),
+	if binPath := tool.FindBinary(root, binName); binPath != "" {
+		return binPath, nil
 	}
 
-	for _, candidate := range candidates {
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
-		}
-	}
-
-	return "", fmt.Errorf("binary %q not found under %s", binName, root)
+	return "", fmt.Errorf("%w: %q under %s", ErrBinaryNotFound, binName, root)
 }
 
 func install(ctx context.Context, misePath string) error {
@@ -127,7 +131,7 @@ func install(ctx context.Context, misePath string) error {
 	defer logging.Close(ctx, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download installer: HTTP %d", resp.StatusCode)
+		return fmt.Errorf("%w: HTTP %d", ErrHTTPDownloadFailed, resp.StatusCode)
 	}
 
 	scriptBytes, err := io.ReadAll(resp.Body)
@@ -150,7 +154,7 @@ func install(ctx context.Context, misePath string) error {
 	}
 
 	if _, err := os.Stat(misePath); err != nil {
-		return fmt.Errorf("mise installation failed - binary not found at %s", misePath)
+		return fmt.Errorf("%w: binary not found at %s", ErrMiseInstallFailed, misePath)
 	}
 
 	return nil

--- a/pkg/modfile/lock_hash.go
+++ b/pkg/modfile/lock_hash.go
@@ -31,7 +31,7 @@ func PopulateSourceLockHashes(ctx context.Context, modFile *ModFile, modulesBase
 
 		provider, ok := getSourceProvider(providerID)
 		if !ok {
-			return fmt.Errorf("source %q provider %q not supported for lock hash", alias, providerID)
+			return fmt.Errorf("source %q: %w: %q", alias, ErrUnsupportedProvider, providerID)
 		}
 		normalized := provider.Normalize(src)
 		if strings.TrimSpace(normalized.URL) != "" {
@@ -43,7 +43,7 @@ func PopulateSourceLockHashes(ctx context.Context, modFile *ModFile, modulesBase
 		}
 		hash = strings.TrimSpace(hash)
 		if hash == "" {
-			return fmt.Errorf("source %q: provider %q returned empty hash", alias, providerID)
+			return fmt.Errorf("source %q: %w: provider %q", alias, ErrEmptyHash, providerID)
 		}
 		if strings.TrimSpace(resolved.URL) != "" {
 			entry.URL = strings.TrimSpace(resolved.URL)

--- a/pkg/modfile/modfile.go
+++ b/pkg/modfile/modfile.go
@@ -1,11 +1,23 @@
 package modfile
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"workspaced/pkg/configcue"
 	parsespec "workspaced/pkg/parse/spec"
+)
+
+var (
+	ErrInvalidSourceSpec   = errors.New("expected provider:target[@ref]")
+	ErrUnsupportedProvider = errors.New("source provider not supported for lock hash")
+	ErrEmptyHash           = errors.New("provider returned empty hash")
+	ErrInvalidLockEntry    = errors.New("invalid lock entry")
+	ErrInputNotConfigured  = errors.New("module references input without config")
+	ErrUnknownInput        = errors.New("unknown input")
+	ErrInputMissingFrom    = errors.New("input is missing from field")
+	ErrLockEntryShrunk     = errors.New("refusing to shrink source lock entries")
 )
 
 type SourceConfig struct {
@@ -218,7 +230,7 @@ func normalizeGitHubRepo(in string) string {
 func ParseSourceSpec(spec string) (SourceConfig, error) {
 	trimmed := strings.TrimSpace(spec)
 	if !strings.Contains(trimmed, ":") {
-		return SourceConfig{}, fmt.Errorf("expected provider:target[@ref]")
+		return SourceConfig{}, ErrInvalidSourceSpec
 	}
 
 	ts, err := parsespec.Parse(trimmed)

--- a/pkg/modfile/module_ref.go
+++ b/pkg/modfile/module_ref.go
@@ -50,7 +50,7 @@ func ResolveModuleFromConfig(cfg *configcue.Config, moduleName string, modCfg co
 	}
 
 	if cfg == nil {
-		return ResolvedModuleSource{}, fmt.Errorf("module %q references input %q without config", moduleName, inputName)
+		return ResolvedModuleSource{}, fmt.Errorf("%w: module %q references input %q", ErrInputNotConfigured, moduleName, inputName)
 	}
 	inputs, err := cfg.Inputs()
 	if err != nil {
@@ -58,11 +58,11 @@ func ResolveModuleFromConfig(cfg *configcue.Config, moduleName string, modCfg co
 	}
 	input, ok := inputs[inputName]
 	if !ok {
-		return ResolvedModuleSource{}, fmt.Errorf("module %q references unknown input %q", moduleName, inputName)
+		return ResolvedModuleSource{}, fmt.Errorf("%w: module %q references %q", ErrUnknownInput, moduleName, inputName)
 	}
 	spec := strings.TrimSpace(input.From)
 	if spec == "" {
-		return ResolvedModuleSource{}, fmt.Errorf("input %q is missing from", inputName)
+		return ResolvedModuleSource{}, fmt.Errorf("%w: %q", ErrInputMissingFrom, inputName)
 	}
 	modFile, err := ModFileFromConfig(cfg)
 	if err != nil {

--- a/pkg/modfile/runner.go
+++ b/pkg/modfile/runner.go
@@ -2,8 +2,13 @@ package modfile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"workspaced/pkg/configcue"
+)
+
+var (
+	ErrNilConfig = errors.New("config is nil")
 )
 
 type LockResult struct {
@@ -20,7 +25,7 @@ func GenerateLock(ctx context.Context, ws *Workspace) (LockResult, error) {
 
 func GenerateLockWithConfig(ctx context.Context, ws *Workspace, cfg *configcue.Config) (LockResult, error) {
 	if cfg == nil {
-		return LockResult{}, fmt.Errorf("failed to load config: config is nil")
+		return LockResult{}, fmt.Errorf("failed to load config: %w", ErrNilConfig)
 	}
 
 	if err := ws.EnsureFiles(ctx); err != nil {
@@ -45,7 +50,7 @@ func GenerateLockWithConfig(ctx context.Context, ws *Workspace, cfg *configcue.C
 		}
 		afterSources := len(sum.SourceLocks())
 		if afterSources < beforeSources {
-			return false, fmt.Errorf("refusing to shrink source lock entries: before=%d after=%d", beforeSources, afterSources)
+			return false, fmt.Errorf("%w: before=%d after=%d", ErrLockEntryShrunk, beforeSources, afterSources)
 		}
 		return changed, nil
 	})

--- a/pkg/modfile/sourceprovider/github/provider.go
+++ b/pkg/modfile/sourceprovider/github/provider.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,10 @@ import (
 	"workspaced/pkg/logging"
 	"workspaced/pkg/modfile"
 	"workspaced/pkg/modfile/sourceprovider/common"
+)
+
+var (
+	ErrMissingCachedHash = errors.New("missing cached source hash metadata")
 )
 
 type Provider struct{}
@@ -42,7 +47,7 @@ func (p Provider) LockHash(ctx context.Context, alias string, src modfile.Source
 		return "", src, fmt.Errorf("failed to read source metadata: %w", err)
 	}
 	if strings.TrimSpace(meta.Hash) == "" {
-		return "", src, fmt.Errorf("missing cached source hash metadata")
+		return "", src, ErrMissingCachedHash
 	}
 
 	normalized.Config.URL = strings.TrimSpace(meta.URL)

--- a/pkg/modfile/sourceprovider/github/resolve_ref.go
+++ b/pkg/modfile/sourceprovider/github/resolve_ref.go
@@ -2,9 +2,16 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+)
+
+var (
+	ErrRepoRequired        = errors.New("github source requires repo")
+	ErrMissingDefaultBranch = errors.New("missing default_branch in github response")
+	ErrMissingSHA           = errors.New("missing sha in github response")
 )
 
 var shaRefRe = regexp.MustCompile(`^[a-fA-F0-9]{7,40}$`)
@@ -15,7 +22,7 @@ func (s Source) ResolvePinnedTarballURL(ctx context.Context) (string, error) {
 	}
 	repo := s.Repo()
 	if repo == "" {
-		return "", fmt.Errorf("github source requires repo")
+		return "", ErrRepoRequired
 	}
 
 	ref := strings.TrimSpace(s.Config.Ref)
@@ -46,7 +53,7 @@ func (s Source) resolveDefaultBranch(ctx context.Context, repo string) (string, 
 		return "", fmt.Errorf("repo metadata lookup failed: %w", err)
 	}
 	if strings.TrimSpace(payload.DefaultBranch) == "" {
-		return "", fmt.Errorf("missing default_branch in github response")
+		return "", ErrMissingDefaultBranch
 	}
 	return strings.TrimSpace(payload.DefaultBranch), nil
 }
@@ -60,7 +67,7 @@ func (s Source) resolveCommitSHA(ctx context.Context, repo string, ref string) (
 		return "", fmt.Errorf("commit lookup failed: %w", err)
 	}
 	if strings.TrimSpace(payload.SHA) == "" {
-		return "", fmt.Errorf("missing sha in github response")
+		return "", ErrMissingSHA
 	}
 	return strings.TrimSpace(payload.SHA), nil
 }

--- a/pkg/modfile/sumfile.go
+++ b/pkg/modfile/sumfile.go
@@ -142,10 +142,10 @@ func normalizeSources(sources map[string]LockedSource) error {
 		lock.URL = strings.TrimSpace(lock.URL)
 		lock.Hash = strings.TrimSpace(lock.Hash)
 		if lock.Provider == "" {
-			return fmt.Errorf("invalid lock entry for source %q: provider is required", name)
+			return fmt.Errorf("%w: source %q: provider is required", ErrInvalidLockEntry, name)
 		}
 		if lock.Hash == "" {
-			return fmt.Errorf("invalid lock entry for source %q: hash is required", name)
+			return fmt.Errorf("%w: source %q: hash is required", ErrInvalidLockEntry, name)
 		}
 		sources[name] = lock
 	}
@@ -157,10 +157,10 @@ func normalizeTools(tools map[string]LockedTool) error {
 		lock.Ref = strings.TrimSpace(lock.Ref)
 		lock.Version = strings.TrimSpace(lock.Version)
 		if lock.Ref == "" {
-			return fmt.Errorf("invalid lock entry for tool %q: ref is required", name)
+			return fmt.Errorf("%w: tool %q: ref is required", ErrInvalidLockEntry, name)
 		}
 		if lock.Version == "" {
-			return fmt.Errorf("invalid lock entry for tool %q: version is required", name)
+			return fmt.Errorf("%w: tool %q: version is required", ErrInvalidLockEntry, name)
 		}
 		tools[name] = lock
 	}

--- a/pkg/module/provider/core/provider.go
+++ b/pkg/module/provider/core/provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -19,6 +20,12 @@ import (
 func init() {
 	module.RegisterProvider(&Provider{})
 }
+
+var (
+	ErrInputDirRequired     = errors.New("input_dir is required for core:base16-icons-linux")
+	ErrThemeNameRequired    = errors.New("theme_name is required")
+	ErrInvalidBase16Config  = errors.New("invalid modules.base16 config")
+)
 
 type Provider struct{}
 
@@ -64,7 +71,7 @@ func (p *Provider) resolveBase16IconsLinux(ctx context.Context, req module.Resol
 	}
 
 	if strings.TrimSpace(cfg.InputDir) == "" {
-		return nil, fmt.Errorf("input_dir is required for core:base16-icons-linux")
+		return nil, ErrInputDirRequired
 	}
 	cfg.InputDir = env.ExpandPath(cfg.InputDir)
 	if cfg.OutputDir == "" {
@@ -76,7 +83,7 @@ func (p *Provider) resolveBase16IconsLinux(ctx context.Context, req module.Resol
 		return nil, fmt.Errorf("invalid input_dir %q: %w", cfg.InputDir, err)
 	}
 	if cfg.ThemeName == "" {
-		return nil, fmt.Errorf("theme_name is required")
+		return nil, ErrThemeNameRequired
 	}
 
 	palette, err := extractBase16(req)
@@ -157,7 +164,7 @@ func extractBase16(req module.ResolveRequest) (map[string]any, error) {
 		return nil, fmt.Errorf("module %q from core:base16-icons-linux requires modules.base16", req.ModuleName)
 	}
 	if entry.Config == nil {
-		return nil, fmt.Errorf("invalid modules.base16 config")
+		return nil, ErrInvalidBase16Config
 	}
 	return entry.Config, nil
 }

--- a/pkg/module/provider/local/provider.go
+++ b/pkg/module/provider/local/provider.go
@@ -2,12 +2,20 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"workspaced/pkg/module"
 	"workspaced/pkg/modulecue"
+)
+
+var (
+	ErrModuleNotFound          = errors.New("workspace module not found")
+	ErrStrictStructureViolation = errors.New("strict structure violation: file found in module root")
+	ErrUnknownPreset           = errors.New("unknown preset")
+	ErrMissingModuleCue        = errors.New("module is missing module.cue")
 )
 
 func init() {
@@ -35,7 +43,7 @@ func (p *Provider) Resolve(ctx context.Context, req module.ResolveRequest) ([]mo
 		modPath = filepath.Join(workspaceRoot, req.Ref)
 	}
 	if st, err := os.Stat(modPath); err != nil || !st.IsDir() {
-		return nil, fmt.Errorf("workspace module %q not found at %s", req.Ref, modPath)
+		return nil, fmt.Errorf("%w: %q at %s", ErrModuleNotFound, req.Ref, modPath)
 	}
 
 	if err := validateConfig(req.Ref, modPath, req.ModuleConfig, req.Config.Raw()); err != nil {
@@ -54,12 +62,12 @@ func (p *Provider) Resolve(ctx context.Context, req module.ResolveRequest) ([]mo
 			if name == "README.md" || strings.HasSuffix(name, ".cue") {
 				continue
 			}
-			return nil, fmt.Errorf("strict structure violation: file %q found in module %q root", name, req.Ref)
+			return nil, fmt.Errorf("%w: %q in module %q", ErrStrictStructureViolation, name, req.Ref)
 		}
 		presetName := preset.Name()
 		targetBase, ok := presetBases[presetName]
 		if !ok {
-			return nil, fmt.Errorf("unknown preset %q in module %q", presetName, req.Ref)
+			return nil, fmt.Errorf("%w: %q in module %q", ErrUnknownPreset, presetName, req.Ref)
 		}
 		if targetBase == "~" {
 			home, _ := os.UserHomeDir()
@@ -96,7 +104,7 @@ func (p *Provider) Resolve(ctx context.Context, req module.ResolveRequest) ([]mo
 
 func validateConfig(modName string, modPath string, modCfg map[string]any, root map[string]any) error {
 	if !modulecue.Exists(modPath) {
-		return fmt.Errorf("module %q is missing module.cue", modName)
+		return fmt.Errorf("%w: %q", ErrMissingModuleCue, modName)
 	}
 	return modulecue.ValidateConfigWithRoot(modPath, modCfg, root)
 }

--- a/pkg/module/registry.go
+++ b/pkg/module/registry.go
@@ -1,9 +1,15 @@
 package module
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+)
+
+var (
+	ErrUnknownProvider  = errors.New("unknown module provider")
+	ErrInvalidModuleRef = errors.New("invalid module from (expected provider:ref)")
 )
 
 var (
@@ -22,7 +28,7 @@ func GetProvider(id string) (Provider, error) {
 	defer providersMu.RUnlock()
 	p, ok := providers[id]
 	if !ok {
-		return nil, fmt.Errorf("unknown module provider %q", id)
+		return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, id)
 	}
 	return p, nil
 }
@@ -34,12 +40,12 @@ func ResolveProviderAndRef(from string, moduleName string) (string, string, erro
 	}
 	parts := strings.SplitN(f, ":", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid module from %q (expected provider:ref)", from)
+		return "", "", fmt.Errorf("%w: %q", ErrInvalidModuleRef, from)
 	}
 	provider := strings.TrimSpace(parts[0])
 	ref := strings.TrimSpace(parts[1])
 	if provider == "" || ref == "" {
-		return "", "", fmt.Errorf("invalid module from %q (expected provider:ref)", from)
+		return "", "", fmt.Errorf("%w: %q", ErrInvalidModuleRef, from)
 	}
 	return provider, ref, nil
 }

--- a/pkg/modulecue/modulecue.go
+++ b/pkg/modulecue/modulecue.go
@@ -2,6 +2,7 @@ package modulecue
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -258,7 +259,7 @@ func cueExprFromAny(v any) (ast.Expr, error) {
 		}
 		return ast.NewList(exprs...), nil
 	default:
-		return nil, fmt.Errorf("unsupported cue context value type %T", v)
+		return nil, fmt.Errorf("%w: %T", ErrUnsupportedValueType, v)
 	}
 }
 
@@ -269,18 +270,25 @@ func numberExpr(s string) (ast.Expr, error) {
 	return ast.NewLit(token.INT, s), nil
 }
 
+var (
+	ErrModuleFieldNotFound       = errors.New("module field not found")
+	ErrModuleFieldNotStruct      = errors.New("module field is not a struct")
+	ErrModuleConfigFieldNotFound = errors.New("module.config field not found")
+	ErrUnsupportedValueType      = errors.New("unsupported cue context value type")
+)
+
 func findModuleConfigExpr(file *ast.File) (ast.Expr, error) {
 	moduleField := findField(file.Decls, "module")
 	if moduleField == nil {
-		return nil, fmt.Errorf("module field not found")
+		return nil, ErrModuleFieldNotFound
 	}
 	moduleStruct, ok := moduleField.Value.(*ast.StructLit)
 	if !ok {
-		return nil, fmt.Errorf("module field is not a struct")
+		return nil, ErrModuleFieldNotStruct
 	}
 	configField := findField(moduleStruct.Elts, "config")
 	if configField == nil {
-		return nil, fmt.Errorf("module.config field not found")
+		return nil, ErrModuleConfigFieldNotFound
 	}
 	return configField.Value, nil
 }

--- a/pkg/nix/nix.go
+++ b/pkg/nix/nix.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -115,7 +114,7 @@ func RemoteBuild(ctx context.Context, ref string, target string, copyBack bool) 
 	}
 
 	// 1. Resolve source
-	updateProgress("Resolvendo metadados do flake...", 0.1)
+	updateProgress("Resolving flake metadata...", 0.1)
 	repo, item := parseFlakeRef(ref)
 
 	sourcePath, err := ResolveFlakePath(ctx, repo)
@@ -124,13 +123,13 @@ func RemoteBuild(ctx context.Context, ref string, target string, copyBack bool) 
 	}
 
 	// 2. Sync source to target
-	updateProgress(fmt.Sprintf("Sincronizando fontes para %s...", target), 0.3)
+	updateProgress(fmt.Sprintf("Syncing sources to %s...", target), 0.3)
 	if err := CopyClosure(ctx, target, sourcePath, To); err != nil {
 		return "", fmt.Errorf("failed to copy source to %s: %w", target, err)
 	}
 
 	// 3. Remote build
-	updateProgress("Compilando no servidor remoto...", 0.6)
+	updateProgress("Building on remote server...", 0.6)
 	remoteCache, err := GetRemoteCacheDir(ctx, target)
 	if err != nil {
 		return "", fmt.Errorf("failed to get remote cache dir: %w", err)
@@ -168,13 +167,13 @@ func RemoteBuild(ctx context.Context, ref string, target string, copyBack bool) 
 
 	// 4. Copy back
 	if copyBack {
-		updateProgress("Sincronizando resultado de volta...", 0.9)
+		updateProgress("Syncing result back...", 0.9)
 		if err := CopyClosure(ctx, target, resultPath, From); err != nil {
 			return "", fmt.Errorf("failed to copy result from %s: %w", target, err)
 		}
 	}
 
-	updateProgress("Build concluído com sucesso.", 1.0)
+	updateProgress("Build completed successfully.", 1.0)
 	return resultPath, nil
 }
 
@@ -313,7 +312,7 @@ func HomeManagerSwitch(ctx context.Context, action string, flake string) error {
 
 func GetFlakeOutput(ctx context.Context, flake, output string) (string, error) {
 	cmd := execdriver.MustRun(ctx, "nix", "build", fmt.Sprintf("%s#%s", flake, output), "--no-link", "--print-out-paths")
-	if stderr, ok := ctx.Value(types.StderrKey).(io.Writer); ok {
+	if stderr := executil.Stderr(ctx); stderr != nil {
 		cmd.Stderr = stderr
 	}
 	out, err := cmd.Output()

--- a/pkg/parse/spec/spec.go
+++ b/pkg/parse/spec/spec.go
@@ -1,8 +1,14 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+)
+
+var (
+	// ErrEmptySpec is returned when an empty spec string is provided.
+	ErrEmptySpec = errors.New("spec cannot be empty")
 )
 
 type Spec struct {
@@ -21,7 +27,7 @@ func (s Spec) String() string {
 
 func Parse(input string) (Spec, error) {
 	if input == "" {
-		return Spec{}, fmt.Errorf("spec cannot be empty")
+		return Spec{}, ErrEmptySpec
 	}
 
 	const defaultProvider = "registry"

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -119,6 +119,24 @@ func (v SemVer) Equal(other SemVer) bool {
 	return v.Compare(other) == 0
 }
 
+// ParseNumericPrefix extracts the leading numeric portion of a string.
+// For example, "3-beta" → 3, "" → 0.
+func ParseNumericPrefix(s string) int {
+	numPart := ""
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			numPart += string(r)
+		} else {
+			break
+		}
+	}
+	if numPart == "" {
+		return 0
+	}
+	n, _ := strconv.Atoi(numPart)
+	return n
+}
+
 // SemVers is a slice of SemVer that implements sort.Interface
 type SemVers []SemVer
 

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -1,0 +1,74 @@
+package semver
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantOrig string
+	}{
+		{name: "simple", input: "1.2.3", wantLen: 3, wantOrig: "1.2.3"},
+		{name: "v prefix", input: "v1.2.3", wantLen: 3, wantOrig: "v1.2.3"},
+		{name: "latest", input: "latest", wantLen: 0, wantOrig: "latest"},
+		{name: "prerelease", input: "1.0.0-beta", wantLen: 3, wantOrig: "1.0.0-beta"},
+		{name: "two parts", input: "3.14", wantLen: 2, wantOrig: "3.14"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.input)
+			if got.Original != tt.wantOrig {
+				t.Errorf("Original = %q, want %q", got.Original, tt.wantOrig)
+			}
+			if len(got.Parts) != tt.wantLen {
+				t.Errorf("len(Parts) = %d, want %d", len(got.Parts), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{name: "equal", a: "1.2.3", b: "1.2.3", want: 0},
+		{name: "less", a: "1.2.3", b: "1.2.4", want: -1},
+		{name: "greater", a: "2.0.0", b: "1.9.9", want: 1},
+		{name: "v prefix equal", a: "v1.0.0", b: "1.0.0", want: 0},
+		{name: "latest vs version", a: "latest", b: "99.0.0", want: 1},
+		{name: "version vs latest", a: "1.0.0", b: "latest", want: -1},
+		{name: "both latest", a: "latest", b: "latest", want: 0},
+		{name: "different lengths", a: "1.0", b: "1.0.0", want: 0},
+		{name: "different lengths unequal", a: "1.0", b: "1.0.1", want: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.a).Compare(Parse(tt.b))
+			if got != tt.want {
+				t.Errorf("Compare(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalized(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{"latest", "latest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Parse(tt.input).Normalized()
+			if got != tt.want {
+				t.Errorf("Normalized() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/shellgen/completion.go
+++ b/pkg/shellgen/completion.go
@@ -1,14 +1,20 @@
 package shellgen
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+)
+
+var (
+	// ErrRootCommandNotSet is returned when shell completion is requested before setting the root command.
+	ErrRootCommandNotSet = errors.New("root command not set, call SetRootCommand first")
 )
 
 // GenerateCompletion generates bash completion using cobra API directly (no exec)
 func GenerateCompletion() (string, error) {
 	if rootCommand == nil {
-		return "", fmt.Errorf("root command not set, call SetRootCommand first")
+		return "", ErrRootCommandNotSet
 	}
 
 	// Generate completion directly using cobra API (much faster than exec)

--- a/pkg/shellgen/shellgen.go
+++ b/pkg/shellgen/shellgen.go
@@ -2,6 +2,7 @@ package shellgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -82,7 +83,7 @@ func Generate(ctx context.Context) (string, error) {
 	}
 
 	if len(errs) > 0 {
-		return "", fmt.Errorf("generator errors: %v", errs)
+		return "", errors.Join(errs...)
 	}
 
 	// Build output in order (sorted by key)

--- a/pkg/source/lazy_file.go
+++ b/pkg/source/lazy_file.go
@@ -8,7 +8,7 @@ import (
 	"workspaced/pkg/template"
 )
 
-// TemplateFile representa um template renderizado sob demanda
+// TemplateFile represents a lazily-rendered template file.
 type TemplateFile struct {
 	BasicFile
 	SourceFile File
@@ -39,7 +39,7 @@ func (f *TemplateFile) Reader() (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(rendered)), nil
 }
 
-// ConcatenatedFile representa múltiplos arquivos unidos (DotD)
+// ConcatenatedFile represents multiple files concatenated together (DotD).
 type ConcatenatedFile struct {
 	BasicFile
 	Components []File

--- a/pkg/source/pipeline.go
+++ b/pkg/source/pipeline.go
@@ -6,33 +6,32 @@ import (
 	"workspaced/pkg/logging"
 )
 
-// Plugin processa lista de arquivos e retorna nova lista
-// Inspirado no padrão de plugins do Beancount
+// Plugin processes a list of files and returns a new list.
 type Plugin interface {
-	// Name retorna nome do plugin (para logging)
+	// Name returns the plugin name (for logging).
 	Name() string
 
-	// Process transforma lista de arquivos
-	// Pode adicionar, remover, modificar arquivos
+	// Process transforms a list of files.
+	// It can add, remove, or modify files.
 	Process(ctx context.Context, files []File) ([]File, error)
 }
 
-// Pipeline executa sequência de plugins
+// Pipeline executes a sequence of plugins.
 type Pipeline struct {
 	plugins []Plugin
 }
 
-// NewPipeline cria pipeline com plugins
+// NewPipeline creates a pipeline with the given plugins.
 func NewPipeline(plugins ...Plugin) *Pipeline {
 	return &Pipeline{plugins: plugins}
 }
 
-// AddPlugin adiciona plugin ao final do pipeline
+// AddPlugin appends a plugin to the end of the pipeline.
 func (p *Pipeline) AddPlugin(plugin Plugin) {
 	p.plugins = append(p.plugins, plugin)
 }
 
-// Run executa pipeline completo
+// Run executes the full pipeline.
 func (p *Pipeline) Run(ctx context.Context, initial []File) ([]File, error) {
 	logger := logging.GetLogger(ctx)
 	current := initial
@@ -53,7 +52,7 @@ func (p *Pipeline) Run(ctx context.Context, initial []File) ([]File, error) {
 	return current, nil
 }
 
-// GetPlugins retorna lista de plugins configurados
+// GetPlugins returns the list of configured plugins.
 func (p *Pipeline) GetPlugins() []Plugin {
 	return p.plugins
 }

--- a/pkg/source/plugin_dotd.go
+++ b/pkg/source/plugin_dotd.go
@@ -8,13 +8,13 @@ import (
 	"workspaced/pkg/template"
 )
 
-// DotDProcessorPlugin processa diretórios .d.tmpl (concatenação)
+// DotDProcessorPlugin processes .d.tmpl directories (concatenation).
 type DotDProcessorPlugin struct {
 	engine *template.Engine
 	data   any
 }
 
-// NewDotDProcessorPlugin cria plugin de processamento .d.tmpl
+// NewDotDProcessorPlugin creates a .d.tmpl processing plugin.
 func NewDotDProcessorPlugin(engine *template.Engine, data any) *DotDProcessorPlugin {
 	return &DotDProcessorPlugin{
 		engine: engine,

--- a/pkg/source/plugin_provider.go
+++ b/pkg/source/plugin_provider.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 )
 
-// ProviderPlugin adapta um Provider para Plugin
-// Permite usar providers legacy no sistema de pipeline
+// ProviderPlugin adapts a Provider to the Plugin interface.
+// Allows legacy providers to be used in the pipeline system.
 type ProviderPlugin struct {
 	provider Provider
 	priority int
 }
 
-// NewProviderPlugin cria plugin a partir de provider legacy
+// NewProviderPlugin creates a plugin from a legacy provider.
 func NewProviderPlugin(provider Provider, priority int) *ProviderPlugin {
 	return &ProviderPlugin{
 		provider: provider,
@@ -30,14 +30,14 @@ func (p *ProviderPlugin) Process(ctx context.Context, files []File) ([]File, err
 		return nil, fmt.Errorf("provider %s failed: %w", p.provider.Name(), err)
 	}
 
-	// Converter DesiredState para source.File
+	// Convert DesiredState to source.File
 	newFiles := make([]File, len(desired))
 	for i, d := range desired {
-		// Providers legacy sempre retornam BufferFiles ou StaticFiles construídos a partir de DesiredState legacy.
-		// No novo modelo, DesiredState já contém um File interface.
+		// Legacy providers always return BufferFiles or StaticFiles built from legacy DesiredState.
+		// In the new model, DesiredState already contains a File interface.
 		newFiles[i] = d.File
 	}
 
-	// Append aos arquivos existentes
+	// Append to existing files
 	return append(files, newFiles...), nil
 }

--- a/pkg/source/plugin_scanner.go
+++ b/pkg/source/plugin_scanner.go
@@ -2,13 +2,23 @@ package source
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-// ScannerPlugin descobre arquivos em um diretório
+var (
+	// ErrScannerNameRequired is returned when a scanner plugin is created without a name.
+	ErrScannerNameRequired = errors.New("scanner name is required")
+	// ErrBaseDirectoryRequired is returned when a scanner plugin is created without a base directory.
+	ErrBaseDirectoryRequired = errors.New("base directory is required")
+	// ErrBaseDirNotExist is returned when the scanner's base directory does not exist.
+	ErrBaseDirNotExist = errors.New("base directory does not exist")
+)
+
+// ScannerPlugin discovers files in a directory.
 type ScannerPlugin struct {
 	name       string
 	baseDir    string
@@ -16,21 +26,21 @@ type ScannerPlugin struct {
 	priority   int
 }
 
-// ScannerConfig configura um ScannerPlugin
+// ScannerConfig configures a ScannerPlugin.
 type ScannerConfig struct {
-	Name       string // Nome identificador
-	BaseDir    string // Diretório fonte (onde estão os arquivos)
-	TargetBase string // Base path para targets (opcional, default: $HOME)
-	Priority   int    // Priority em conflitos
+	Name       string // Unique identifier
+	BaseDir    string // Source directory (where the files are)
+	TargetBase string // Base path for targets (optional, default: $HOME)
+	Priority   int    // Priority in conflicts
 }
 
-// NewScannerPlugin cria um plugin scanner
+// NewScannerPlugin creates a scanner plugin.
 func NewScannerPlugin(cfg ScannerConfig) (*ScannerPlugin, error) {
 	if cfg.Name == "" {
-		return nil, fmt.Errorf("scanner name is required")
+		return nil, ErrScannerNameRequired
 	}
 	if cfg.BaseDir == "" {
-		return nil, fmt.Errorf("base directory is required")
+		return nil, ErrBaseDirectoryRequired
 	}
 
 	// Expand paths
@@ -40,9 +50,9 @@ func NewScannerPlugin(cfg ScannerConfig) (*ScannerPlugin, error) {
 		baseDir = filepath.Join(home, baseDir[2:])
 	}
 
-	// Verificar se diretório existe
+	// Check if directory exists
 	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("base directory does not exist: %s", baseDir)
+		return nil, fmt.Errorf("%w: %s", ErrBaseDirNotExist, baseDir)
 	}
 
 	// Target base (default: $HOME)
@@ -75,12 +85,12 @@ func (p *ScannerPlugin) Process(ctx context.Context, files []File) ([]File, erro
 			return err
 		}
 
-		// Skip diretórios por enquanto (serão processados depois)
+		// Skip directories (processed separately)
 		if info.IsDir() {
 			return nil
 		}
 
-		// Calcular caminho relativo
+		// Calculate relative path
 		rel, err := filepath.Rel(p.baseDir, path)
 		if err != nil {
 			return err
@@ -109,6 +119,6 @@ func (p *ScannerPlugin) Process(ctx context.Context, files []File) ([]File, erro
 		return nil, fmt.Errorf("failed to scan directory: %w", err)
 	}
 
-	// Append aos arquivos existentes
+	// Append to existing files
 	return append(files, discovered...), nil
 }

--- a/pkg/source/plugin_template.go
+++ b/pkg/source/plugin_template.go
@@ -11,13 +11,13 @@ import (
 	"workspaced/pkg/template"
 )
 
-// TemplateExpanderPlugin renderiza templates e expande multi-file
+// TemplateExpanderPlugin renders templates and expands multi-file output.
 type TemplateExpanderPlugin struct {
 	engine *template.Engine
 	data   any
 }
 
-// NewTemplateExpanderPlugin cria plugin de expansão de templates
+// NewTemplateExpanderPlugin creates a template expansion plugin.
 func NewTemplateExpanderPlugin(engine *template.Engine, data any) *TemplateExpanderPlugin {
 	return &TemplateExpanderPlugin{
 		engine: engine,
@@ -34,19 +34,19 @@ func (p *TemplateExpanderPlugin) Process(ctx context.Context, files []File) ([]F
 	globalCfg, _ := p.data.(*configcue.Config)
 
 	for _, f := range files {
-		// Detectar se é template
+		// Detect if the file is a template
 		filename := filepath.Base(f.RelPath())
 		parts := strings.Split(filename, ".")
 		isTemplate := (len(parts) >= 2 && parts[len(parts)-1] == "tmpl") ||
 			(len(parts) >= 3 && parts[len(parts)-2] == "tmpl")
 
 		if !isTemplate {
-			// Não é template, passa adiante
+			// Not a template, pass through
 			result = append(result, f)
 			continue
 		}
 
-		// Calcular RelPath sem .tmpl
+		// Compute RelPath without .tmpl
 		relPath := f.RelPath()
 		if parts[len(parts)-1] == "tmpl" {
 			// file.tmpl → file
@@ -82,11 +82,11 @@ func (p *TemplateExpanderPlugin) Process(ctx context.Context, files []File) ([]F
 			return nil, fmt.Errorf("failed to render template %s: %w", f.SourceInfo(), err)
 		}
 
-		// Verificar se é multi-file
+		// Check if the output is multi-file
 		multiFiles, isMulti := template.ParseMultiFile(rendered)
 
 		if isMulti {
-			// UM template → N files (EAGER)
+			// One template → N files (EAGER)
 			baseRelDir := filepath.Dir(relPath)
 			baseName := strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath))
 
@@ -109,7 +109,7 @@ func (p *TemplateExpanderPlugin) Process(ctx context.Context, files []File) ([]F
 				})
 			}
 		} else {
-			// UM template → 1 file (LAZY)
+			// One template → 1 file (LAZY)
 			result = append(result, &TemplateFile{
 				BasicFile: BasicFile{
 					RelPathStr:    relPath,

--- a/pkg/source/types.go
+++ b/pkg/source/types.go
@@ -3,33 +3,38 @@ package source
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 )
 
-// Source representa uma origem de arquivos/templates
+var (
+	// ErrNotSymlink is returned when a non-symlink file is asked for its link target.
+	ErrNotSymlink = errors.New("not a symlink")
+)
+
+// Source represents a file/template origin.
 type Source interface {
-	// Name retorna identificador único da source
+	// Name returns the unique identifier of the source.
 	Name() string
 
-	// Priority define precedência em conflitos (maior = mais prioritário)
+	// Priority defines precedence in conflicts (higher = more priority).
 	Priority() int
 
-	// Scan descobre e retorna todos os arquivos desta source
+	// Scan discovers and returns all files from this source.
 	Scan(ctx context.Context) ([]File, error)
 }
 
-// FileType indica o tipo de processamento necessário
+// FileType indicates the kind of processing required.
 type FileType int
 
 const (
-	TypeSymlink   FileType = iota // Criar symlink direto
-	TypeStatic                    // Copiar arquivo estático (sem template)
-	TypeTemplate                  // Renderizar template simples
-	TypeMultiFile                 // Template que gera múltiplos arquivos
-	TypeDotD                      // Diretório .d.tmpl (concatenação)
+	TypeSymlink   FileType = iota // Create a direct symlink
+	TypeStatic                    // Copy static file (no template)
+	TypeTemplate                  // Render a simple template
+	TypeMultiFile                 // Template that generates multiple files
+	TypeDotD                      // .d.tmpl directory (concatenation)
 )
 
 func (t FileType) String() string {
@@ -49,7 +54,7 @@ func (t FileType) String() string {
 	}
 }
 
-// File representa um arquivo descoberto ou gerado no pipeline
+// File represents a file discovered or generated in the pipeline.
 type File interface {
 	RelPath() string
 	TargetBase() string
@@ -57,7 +62,7 @@ type File interface {
 	Reader() (io.ReadCloser, error)
 	SourceInfo() string
 	Type() FileType
-	// LinkTarget retorna o destino do link se Type() == TypeSymlink
+	// LinkTarget returns the link destination if Type() == TypeSymlink.
 	LinkTarget() (string, error)
 }
 
@@ -66,7 +71,7 @@ type ScopedFile interface {
 	ModuleName() string
 }
 
-// BasicFile implementa os campos comuns de File
+// BasicFile implements common File fields.
 type BasicFile struct {
 	RelPathStr    string
 	TargetBaseDir string
@@ -83,10 +88,10 @@ func (f *BasicFile) SourceInfo() string { return f.Info }
 func (f *BasicFile) Type() FileType     { return f.FileType }
 func (f *BasicFile) ModuleName() string { return f.Module }
 func (f *BasicFile) LinkTarget() (string, error) {
-	return "", fmt.Errorf("not a symlink")
+	return "", ErrNotSymlink
 }
 
-// StaticFile representa um arquivo real no disco
+// StaticFile represents a real file on disk.
 type StaticFile struct {
 	BasicFile
 	AbsPath string
@@ -98,12 +103,12 @@ func (f *StaticFile) Reader() (io.ReadCloser, error) {
 
 func (f *StaticFile) LinkTarget() (string, error) {
 	if f.FileType != TypeSymlink {
-		return "", fmt.Errorf("not a symlink")
+		return "", ErrNotSymlink
 	}
 	return os.Readlink(f.AbsPath)
 }
 
-// BufferFile representa um arquivo com conteúdo em memória
+// BufferFile represents a file with in-memory content.
 type BufferFile struct {
 	BasicFile
 	Content []byte
@@ -113,7 +118,7 @@ func (f *BufferFile) Reader() (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(f.Content)), nil
 }
 
-// DesiredState representa estado desejado de um arquivo
+// DesiredState represents the desired state of a file.
 type DesiredState struct {
 	File File
 }
@@ -122,7 +127,7 @@ func (d DesiredState) Target() string {
 	return filepath.Join(d.File.TargetBase(), d.File.RelPath())
 }
 
-// Provider gera estados desejados (interface legacy, mantida para compatibilidade)
+// Provider generates desired states (legacy interface, kept for compatibility).
 type Provider interface {
 	Name() string
 	GetDesiredState(ctx context.Context) ([]DesiredState, error)

--- a/pkg/taskgroup/taskgroup.go
+++ b/pkg/taskgroup/taskgroup.go
@@ -11,6 +11,7 @@ package taskgroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime"
@@ -18,6 +19,11 @@ import (
 	"sync"
 
 	"workspaced/pkg/logging"
+)
+
+var (
+	ErrUnknownDependency = errors.New("unknown dependency")
+	ErrDependencyFailed  = errors.New("dependency failed")
 )
 
 // PoolKind identifies which resource pool a task consumes a slot from.
@@ -475,7 +481,7 @@ func (g *Group) runTask(t *taskEntry) {
 		depTask, ok := g.byName[dep]
 		g.mu.Unlock()
 		if !ok {
-			t.setError(fmt.Errorf("taskgroup: unknown dependency %q for task %q", dep, t.name))
+			t.setError(fmt.Errorf("taskgroup: %w %q for task %q", ErrUnknownDependency, dep, t.name))
 			g.recordError(t.err)
 			return
 		}
@@ -486,7 +492,7 @@ func (g *Group) runTask(t *taskEntry) {
 			depErr := depTask.err
 			depTask.mu.Unlock()
 			if depErr != nil {
-				t.setError(fmt.Errorf("taskgroup: dependency %q failed: %w", dep, depErr))
+				t.setError(fmt.Errorf("taskgroup: %w: %q: %w", ErrDependencyFailed, dep, depErr))
 				g.recordError(t.err)
 				return
 			}

--- a/pkg/template/dotd.go
+++ b/pkg/template/dotd.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// ProcessDotD processa um diretório .d.tmpl (concatenação de arquivos)
+// ProcessDotD processes a .d.tmpl directory (file concatenation).
 func (e *Engine) ProcessDotD(ctx context.Context, dirPath string, data any) ([]byte, error) {
 	// Check if directory exists
 	if _, err := os.Stat(dirPath); os.IsNotExist(err) {

--- a/pkg/template/engine.go
+++ b/pkg/template/engine.go
@@ -9,15 +9,19 @@ import (
 	"text/template"
 )
 
-// Engine é o motor de renderização de templates do workspaced
+var (
+	ErrNotMultiFile = errors.New("template is not a multi-file template")
+)
+
+// Engine is the workspaced template rendering engine.
 type Engine struct {
 	funcMap template.FuncMap
 }
 
-// Option é uma função de configuração para Engine
+// Option is a configuration function for Engine.
 type Option func(*Engine)
 
-// NewEngine cria uma nova engine de templates
+// NewEngine creates a new template engine.
 func NewEngine(ctx context.Context, opts ...Option) *Engine {
 	e := &Engine{
 		funcMap: makeFuncMap(ctx),
@@ -30,21 +34,21 @@ func NewEngine(ctx context.Context, opts ...Option) *Engine {
 	return e
 }
 
-// WithCustomFunc adiciona uma função customizada ao FuncMap
+// WithCustomFunc adds a custom function to the FuncMap.
 func WithCustomFunc(name string, fn any) Option {
 	return func(e *Engine) {
 		e.funcMap[name] = fn
 	}
 }
 
-// WithFuncMap substitui o FuncMap inteiro
+// WithFuncMap replaces the entire FuncMap.
 func WithFuncMap(funcMap template.FuncMap) Option {
 	return func(e *Engine) {
 		e.funcMap = funcMap
 	}
 }
 
-// Render renderiza um template string com os dados fornecidos
+// Render renders a template string with the provided data.
 func (e *Engine) Render(ctx context.Context, tmpl string, data any) ([]byte, error) {
 	t, err := template.New("template").Funcs(e.funcMap).Parse(tmpl)
 	if err != nil {
@@ -62,7 +66,7 @@ func (e *Engine) Render(ctx context.Context, tmpl string, data any) ([]byte, err
 	return buf.Bytes(), nil
 }
 
-// RenderFile renderiza um arquivo de template
+// RenderFile renders a template file from disk.
 func (e *Engine) RenderFile(ctx context.Context, path string, data any) ([]byte, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -72,7 +76,7 @@ func (e *Engine) RenderFile(ctx context.Context, path string, data any) ([]byte,
 	return e.Render(ctx, string(content), data)
 }
 
-// RenderMultiFile renderiza e retorna múltiplos arquivos
+// RenderMultiFile renders a template and returns multiple output files.
 func (e *Engine) RenderMultiFile(ctx context.Context, tmpl string, data any) ([]MultiFile, error) {
 	rendered, err := e.Render(ctx, tmpl, data)
 	if err != nil {
@@ -81,7 +85,7 @@ func (e *Engine) RenderMultiFile(ctx context.Context, tmpl string, data any) ([]
 
 	files, isMulti := ParseMultiFile(rendered)
 	if !isMulti {
-		return nil, fmt.Errorf("template is not a multi-file template")
+		return nil, ErrNotMultiFile
 	}
 
 	return files, nil

--- a/pkg/template/funcmap.go
+++ b/pkg/template/funcmap.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,10 +18,10 @@ import (
 	"workspaced/pkg/text"
 )
 
-// ErrFileSkipped é retornado quando um template chama {{ skip }}
-var ErrFileSkipped = fmt.Errorf("file skipped")
+// ErrFileSkipped is returned when a template calls {{ skip }}.
+var ErrFileSkipped = errors.New("file skipped")
 
-// makeFuncMap cria o FuncMap padrão do workspaced
+// makeFuncMap creates the default workspaced FuncMap.
 func makeFuncMap(ctx context.Context) template.FuncMap {
 	lockTool, lockSource := makeLockLookups(ctx)
 	return template.FuncMap{

--- a/pkg/text/text_test.go
+++ b/pkg/text/text_test.go
@@ -1,0 +1,29 @@
+package text
+
+import "testing"
+
+func TestToTitleCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "simple", input: "hello world", want: "Hello World"},
+		{name: "hyphen", input: "foo-bar", want: "Foo Bar"},
+		{name: "underscore", input: "foo_bar", want: "Foo Bar"},
+		{name: "mixed separators", input: "hello-world_test", want: "Hello World Test"},
+		{name: "already title case", input: "Hello World", want: "Hello World"},
+		{name: "all upper", input: "HELLO WORLD", want: "Hello World"},
+		{name: "single word", input: "hello", want: "Hello"},
+		{name: "empty", input: "", want: ""},
+		{name: "extra spaces", input: "  foo   bar  ", want: "Foo Bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToTitleCase(tt.input)
+			if got != tt.want {
+				t.Errorf("ToTitleCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tool/backend/backend.go
+++ b/pkg/tool/backend/backend.go
@@ -78,7 +78,7 @@ type BinaryTool interface {
 
 // --- Transitional / compatibility surface ---
 // These are kept while we migrate internal call sites to the Tool-based path.
-// New code should prefer Provider.Tool(ref) + the Tool interface and its extensions.
+// New code should prefer Backend.Tool(ref) + the Tool interface and its extensions.
 
 // PackageConfig is the old package reference shape. It is still used by some
 // transitional code paths and by the current low-level methods on concrete providers.
@@ -89,7 +89,7 @@ type PackageConfig struct {
 }
 
 // BinaryProvider is the old extension interface. Code is being migrated to
-// check for BinaryTool on the value returned by Provider.Tool(ref) instead.
+// check for BinaryTool on the value returned by Backend.Tool(ref) instead.
 type BinaryProvider interface {
 	EnsureBinary(ctx context.Context, pkg PackageConfig, version string, cmdName string, destPath string) (string, error)
 }
@@ -126,7 +126,7 @@ func ContainsAnyOf(haystack string, needles ...string) bool {
 
 // SelectArtifact chooses the best artifact for the given OS/arch from the list,
 // applying optional binary hint scoring (used by both the manager and
-// provider Tool implementations during the migration).
+// backend Tool implementations during the migration).
 //
 // For android, if no android-specific artifact is found for the arch, it
 // falls back to trying linux artifacts (many projects do not publish

--- a/pkg/tool/backend/backend_test.go
+++ b/pkg/tool/backend/backend_test.go
@@ -1,0 +1,49 @@
+package backend
+
+import "testing"
+
+func TestContainsAnyOf(t *testing.T) {
+	tests := []struct {
+		name     string
+		haystack string
+		needles  []string
+		want     bool
+	}{
+		{name: "match first", haystack: "linux-amd64.tar.gz", needles: []string{"linux", "darwin"}, want: true},
+		{name: "match second", haystack: "darwin-arm64.tar.gz", needles: []string{"linux", "darwin"}, want: true},
+		{name: "no match", haystack: "windows-x86.zip", needles: []string{"linux", "darwin"}, want: false},
+		{name: "empty needles", haystack: "anything", needles: nil, want: false},
+		{name: "empty haystack", haystack: "", needles: []string{"linux"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContainsAnyOf(tt.haystack, tt.needles...)
+			if got != tt.want {
+				t.Errorf("ContainsAnyOf(%q, %v) = %v, want %v", tt.haystack, tt.needles, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreArtifactForHint(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		hint string
+		want int
+	}{
+		{name: "empty hint", url: "https://example.com/foo.tar.gz", hint: "", want: 0},
+		{name: "exact token match", url: "https://example.com/resvg-linux.tar.gz", hint: "resvg", want: 190},
+		{name: "substring match", url: "https://example.com/myresvgtool.tar.gz", hint: "resvg", want: 70},
+		{name: "no match", url: "https://example.com/other.tar.gz", hint: "resvg", want: 10},
+		{name: "debug penalty", url: "https://example.com/resvg-debug.tar.gz", hint: "resvg", want: 170},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scoreArtifactForHint(tt.url, tt.hint)
+			if got != tt.want {
+				t.Errorf("scoreArtifactForHint(%q, %q) = %d, want %d", tt.url, tt.hint, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tool/backend/catalog/applications/grok-build.go
+++ b/pkg/tool/backend/catalog/applications/grok-build.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,6 +20,8 @@ import (
 	"workspaced/pkg/tool/backend/catalog"
 	providerinstall "workspaced/pkg/tool/backend/install"
 )
+
+var ErrGrokBuildProbeFailure = errors.New("failed to probe grok-build latest from x.ai channels")
 
 func init() {
 	catalog.RegisterTool("grok-build", newGrokBuild)
@@ -159,7 +162,7 @@ func (t *grokBuildTool) probeLatest(ctx context.Context) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("failed to probe grok-build latest from x.ai channels")
+	return "", ErrGrokBuildProbeFailure
 }
 
 func (t *grokBuildTool) grokPlatform() string {

--- a/pkg/tool/backend/catalog/applications/nodejs.go
+++ b/pkg/tool/backend/catalog/applications/nodejs.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +19,11 @@ import (
 	"workspaced/pkg/tool/backend"
 	"workspaced/pkg/tool/backend/catalog"
 	providerinstall "workspaced/pkg/tool/backend/install"
+)
+
+var (
+	ErrNoNodeVersions    = errors.New("no node versions found")
+	ErrNoPlatformArtifact = errors.New("no artifact for current platform")
 )
 
 func init() {
@@ -42,7 +48,7 @@ func (t *nodejsTool) Install(ctx context.Context, version string, destDir string
 			return err
 		}
 		if len(vers) == 0 {
-			return fmt.Errorf("no node versions found")
+			return ErrNoNodeVersions
 		}
 		v = vers[0]
 	}
@@ -51,7 +57,7 @@ func (t *nodejsTool) Install(ctx context.Context, version string, destDir string
 		return err
 	}
 	if len(arts) == 0 {
-		return fmt.Errorf("no artifact for current platform")
+		return ErrNoPlatformArtifact
 	}
 	return t.InstallArtifact(ctx, arts[0], destDir)
 }
@@ -73,7 +79,7 @@ func (t *nodejsTool) ListArtifacts(ctx context.Context, version string) ([]backe
 			return nil, err
 		}
 		if len(vers) == 0 {
-			return nil, fmt.Errorf("no node versions")
+			return nil, ErrNoNodeVersions
 		}
 		v = vers[0]
 	}

--- a/pkg/tool/backend/catalog/catalog.go
+++ b/pkg/tool/backend/catalog/catalog.go
@@ -1,11 +1,16 @@
 package catalog
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"workspaced/pkg/tool"
 	"workspaced/pkg/tool/backend"
+)
+
+var (
+	ErrEmptyToolName = errors.New("curated tool name cannot be empty")
 )
 
 func init() {
@@ -36,7 +41,7 @@ func (c *catalog) Tool(ref string) (backend.Tool, error) {
 	// See applications/ for the list of github-backed named tools.
 	name := strings.TrimSpace(ref)
 	if name == "" {
-		return nil, fmt.Errorf("curated tool name cannot be empty")
+		return nil, ErrEmptyToolName
 	}
 
 	if ctor, ok := namedTools[name]; ok {

--- a/pkg/tool/backend/github/provider.go
+++ b/pkg/tool/backend/github/provider.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,6 +20,11 @@ import (
 	providerinstall "workspaced/pkg/tool/backend/install"
 )
 
+var (
+	ErrEmptyGitHubRef   = errors.New("github ref cannot be empty (expected owner/repo)")
+	ErrInvalidGitHubRef = errors.New("invalid github ref (expected owner/repo)")
+)
+
 func init() {
 	tool.Register("github", &Provider{})
 }
@@ -33,7 +39,7 @@ func (p *Provider) Tool(ref string) (backend.Tool, error) {
 }
 
 // ParsePackage is kept for transitional use by code that still talks to the
-// old detailed surface on the concrete provider.
+// old detailed surface on the concrete backend.
 func (p *Provider) ParsePackage(spec string) (backend.PackageConfig, error) {
 	parts := strings.Split(spec, "/")
 	if len(parts) != 2 {
@@ -257,29 +263,29 @@ func parseAssetName(name string) (osName, arch string, ok bool) {
 }
 
 // ============================================================================
-// GitHubTool - exported Tool implementation for the github provider
+// GitHubTool - exported Tool implementation for the github backend
 // ============================================================================
 
 // GitHubTool is the concrete Tool for packages distributed via GitHub Releases.
-// It is exported (along with NewTool) so that a future central "registry" provider
+// It is exported (along with NewTool) so that a future central "registry" backend
 // can construct, wrap, or delegate to GitHub-based tools.
 type GitHubTool struct {
 	repo string
-	p    *Provider // delegate to existing provider logic during migration
+	p    *Provider // delegate to existing backend logic during migration
 }
 
 // NewTool constructs a GitHubTool for the given ref ("owner/repo").
-// This is the preferred way for external code (including a future registry provider)
+// This is the preferred way for external code (including a future registry backend)
 // to obtain a github-backed Tool without going through the handler registration.
 func NewTool(ref string) (backend.Tool, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		return nil, fmt.Errorf("github ref cannot be empty (expected owner/repo)")
+		return nil, ErrEmptyGitHubRef
 	}
 	// Basic validation to match old ParsePackage behavior
 	parts := strings.Split(ref, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return nil, fmt.Errorf("invalid github ref %q (expected owner/repo)", ref)
+		return nil, fmt.Errorf("%w: %q", ErrInvalidGitHubRef, ref)
 	}
 	return &GitHubTool{repo: ref, p: &Provider{}}, nil
 }

--- a/pkg/tool/backend/install/install.go
+++ b/pkg/tool/backend/install/install.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,11 @@ import (
 	"workspaced/pkg/logging"
 	"workspaced/pkg/taskgroup"
 	"workspaced/pkg/tool/backend"
+)
+
+var (
+	ErrEmptyDownloadURL  = errors.New("download URL cannot be empty")
+	ErrNoDownloadURLs    = errors.New("no download URLs provided")
 )
 
 type DownloadOptions struct {
@@ -64,7 +70,7 @@ func InstallArtifact(ctx context.Context, artifact backend.Artifact, destDir str
 
 func DownloadFile(ctx context.Context, url, dest string, opts DownloadOptions) error {
 	if strings.TrimSpace(url) == "" {
-		return fmt.Errorf("download url cannot be empty")
+		return ErrEmptyDownloadURL
 	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return err
@@ -101,7 +107,7 @@ func DownloadFirst(ctx context.Context, urls []string, dest string, opts Downloa
 		}
 	}
 	if len(errs) == 0 {
-		return fmt.Errorf("no download urls provided")
+		return ErrNoDownloadURLs
 	}
 	return fmt.Errorf("all downloads failed: %s", strings.Join(errs, "; "))
 }

--- a/pkg/tool/backend/mise/provider.go
+++ b/pkg/tool/backend/mise/provider.go
@@ -2,6 +2,7 @@ package mise
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,15 @@ import (
 	"workspaced/pkg/modfile"
 	"workspaced/pkg/tool"
 	"workspaced/pkg/tool/backend"
+)
+
+var (
+	// ErrEmptyMiseSpec is returned when a mise spec is empty.
+	ErrEmptyMiseSpec = errors.New("mise spec cannot be empty")
+	// ErrEmptyMiseRef is returned when a mise ref is empty.
+	ErrEmptyMiseRef = errors.New("mise ref cannot be empty")
+	// ErrMissingMiseArtifactSpec is returned when a mise artifact spec is empty.
+	ErrMissingMiseArtifactSpec = errors.New("missing mise artifact spec")
 )
 
 type Provider struct{}
@@ -29,7 +39,7 @@ func (p *Provider) Tool(ref string) (backend.Tool, error) {
 func (p *Provider) ParsePackage(spec string) (backend.PackageConfig, error) {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
-		return backend.PackageConfig{}, fmt.Errorf("mise spec cannot be empty")
+		return backend.PackageConfig{}, ErrEmptyMiseSpec
 	}
 	return backend.PackageConfig{
 		Provider: "mise",
@@ -59,7 +69,7 @@ func (p *Provider) Install(ctx context.Context, artifact backend.Artifact, destP
 	_ = destPath
 	spec := strings.TrimSpace(artifact.URL)
 	if spec == "" {
-		return fmt.Errorf("missing mise artifact spec")
+		return ErrMissingMiseArtifactSpec
 	}
 	return miseutil.Run(ctx, "install", spec)
 }
@@ -107,7 +117,7 @@ func ensureSymlink(destPath, binPath, cmdName string) (string, error) {
 }
 
 // ============================================================================
-// MiseTool - exported Tool implementation for the mise provider
+// MiseTool - exported Tool implementation for the mise backend
 // ============================================================================
 
 // MiseTool is the concrete Tool for packages managed via mise.
@@ -122,13 +132,13 @@ type MiseTool struct {
 func NewTool(ref string) (backend.Tool, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		return nil, fmt.Errorf("mise ref cannot be empty")
+		return nil, ErrEmptyMiseRef
 	}
 	return &MiseTool{spec: ref, p: &Provider{}}, nil
 }
 
 func (t *MiseTool) ListVersions(ctx context.Context) ([]string, error) {
-	// mise provider's ListVersions currently only returns the single "latest"
+	// mise backend's ListVersions currently only returns the single "latest"
 	// resolved by the backend. We keep that behavior for the Tool.
 	pkg := backend.PackageConfig{Spec: t.spec}
 	return t.p.ListVersions(ctx, pkg)

--- a/pkg/tool/lazy.go
+++ b/pkg/tool/lazy.go
@@ -2,6 +2,7 @@ package tool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,15 @@ import (
 	parsespec "workspaced/pkg/parse/spec"
 	"workspaced/pkg/taskgroup"
 	"workspaced/pkg/tool/backend"
+)
+
+var (
+	// ErrNilWorkspace is returned when a nil workspace is passed to a function that requires one.
+	ErrNilWorkspace = errors.New("workspace is nil")
+	// ErrNilConfig is returned when a nil config is passed to a function that requires one.
+	ErrNilConfig = errors.New("config is nil")
+	// ErrLazyToolNotFound is returned when a lazy tool alias cannot be found in the workspace or home config.
+	ErrLazyToolNotFound = errors.New("lazy tool not found in workspace or home config")
 )
 
 type lazyToolConfig struct {
@@ -79,10 +89,10 @@ func ResolveHomeLazyTool(ctx context.Context, toolName, binName string) (string,
 // to ensure CI reproducible executions. Returns the count of updated tool definitions.
 func RefreshLazyToolLocks(ctx context.Context, ws *modfile.Workspace, cfg *configcue.Config) (int, error) {
 	if ws == nil {
-		return 0, fmt.Errorf("workspace is nil")
+		return 0, ErrNilWorkspace
 	}
 	if cfg == nil {
-		return 0, fmt.Errorf("config is nil")
+		return 0, ErrNilConfig
 	}
 	if err := ws.EnsureFiles(ctx); err != nil {
 		return 0, err
@@ -234,10 +244,10 @@ type LockRefreshResult struct {
 // and tool (execution) locks, effectively aligning the workspace modfile with the configured states.
 func RefreshWorkspaceLocks(ctx context.Context, ws *modfile.Workspace, cfg *configcue.Config) (LockRefreshResult, error) {
 	if ws == nil {
-		return LockRefreshResult{}, fmt.Errorf("workspace is nil")
+		return LockRefreshResult{}, ErrNilWorkspace
 	}
 	if cfg == nil {
-		return LockRefreshResult{}, fmt.Errorf("config is nil")
+		return LockRefreshResult{}, ErrNilConfig
 	}
 
 	lockResult, err := modfile.GenerateLockWithConfig(ctx, ws, cfg)
@@ -290,7 +300,7 @@ func workspaceRootOrEmpty(ws *modfile.Workspace) string {
 
 func resolveLazyToolInWorkspace(ctx context.Context, ws *modfile.Workspace, toolName, binName string) (string, error) {
 	if ws == nil {
-		return "", fmt.Errorf("workspace is nil")
+		return "", ErrNilWorkspace
 	}
 	logger := logging.GetLogger(ctx)
 
@@ -318,7 +328,7 @@ func resolveLazyToolInWorkspace(ctx context.Context, ws *modfile.Workspace, tool
 		}
 	}
 	if !ok {
-		return "", fmt.Errorf("lazy tool %q not found in workspace or home config", toolName)
+		return "", fmt.Errorf("%w: %s", ErrLazyToolNotFound, toolName)
 	}
 
 	spec, lockRef, err := lazyToolSpec(toolName, toolCfg)

--- a/pkg/tool/paths.go
+++ b/pkg/tool/paths.go
@@ -20,3 +20,28 @@ func GetShimsDir() (string, error) {
 	}
 	return filepath.Join(home, ".local", "share", "workspaced", "shims"), nil
 }
+
+// FindBinary searches for a binary named cmdName in the standard candidate
+// locations under baseDir: baseDir/bin/cmdName, baseDir/bin/cmdName.exe,
+// baseDir/cmdName, baseDir/cmdName.exe. Returns the first existing path
+// or empty string if none found.
+func FindBinary(baseDir, cmdName string) string {
+	for _, path := range BinaryCandidates(baseDir, cmdName) {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// BinaryCandidates returns the list of candidate paths for a binary in
+// the standard layout under baseDir. This is the pure function version
+// useful when you need the list itself rather than the first match.
+func BinaryCandidates(baseDir, cmdName string) []string {
+	return []string{
+		filepath.Join(baseDir, "bin", cmdName),
+		filepath.Join(baseDir, "bin", cmdName+".exe"),
+		filepath.Join(baseDir, cmdName),
+		filepath.Join(baseDir, cmdName+".exe"),
+	}
+}

--- a/pkg/tool/paths_test.go
+++ b/pkg/tool/paths_test.go
@@ -1,0 +1,61 @@
+package tool
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBinaryCandidates(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseDir string
+		cmdName string
+		want    []string
+	}{
+		{
+			name:    "standard layout",
+			baseDir: "/tools/github-cli-cli/2.0.0",
+			cmdName: "gh",
+			want: []string{
+				filepath.Join("/tools/github-cli-cli/2.0.0", "bin", "gh"),
+				filepath.Join("/tools/github-cli-cli/2.0.0", "bin", "gh.exe"),
+				filepath.Join("/tools/github-cli-cli/2.0.0", "gh"),
+				filepath.Join("/tools/github-cli-cli/2.0.0", "gh.exe"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BinaryCandidates(tt.baseDir, tt.cmdName)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(BinaryCandidates) = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("BinaryCandidates[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "v prefix", version: "v1.2.3", want: "1.2.3"},
+		{name: "no prefix", version: "1.2.3", want: "1.2.3"},
+		{name: "with slash", version: "refs/heads/main", want: "refs-heads-main"},
+		{name: "v prefix with slash", version: "v1.0/rc1", want: "1.0-rc1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeVersion(tt.version)
+			if got != tt.want {
+				t.Errorf("normalizeVersion(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tool/resolution/resolver.go
+++ b/pkg/tool/resolution/resolver.go
@@ -3,14 +3,17 @@ package resolution
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"workspaced/pkg/logging"
+	"workspaced/pkg/semver"
 )
+
+var ErrToolNotFound = errors.New("tool not found")
 
 type Resolver struct {
 	toolsDir string
@@ -78,7 +81,7 @@ func (r *Resolver) Resolve(ctx context.Context, toolName string) (string, error)
 	}
 
 	if len(candidates) == 0 {
-		return "", fmt.Errorf("tool %q not found (version: %s)", toolName, version)
+		return "", fmt.Errorf("%w: %q (version: %s)", ErrToolNotFound, toolName, version)
 	}
 
 	// If multiple candidates, pick one.
@@ -89,28 +92,17 @@ func (r *Resolver) Resolve(ctx context.Context, toolName string) (string, error)
 }
 
 func (r *Resolver) checkBin(verDir, toolName string) string {
-	// Check bin/toolName
-	p := filepath.Join(verDir, "bin", toolName)
-	if _, err := os.Stat(p); err == nil {
-		return p
+	candidates := []string{
+		filepath.Join(verDir, "bin", toolName),
+		filepath.Join(verDir, "bin", toolName+".exe"),
+		filepath.Join(verDir, toolName),
+		filepath.Join(verDir, toolName+".exe"),
 	}
-	// Check bin/toolName.exe
-	p = filepath.Join(verDir, "bin", toolName+".exe")
-	if _, err := os.Stat(p); err == nil {
-		return p
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
 	}
-
-	// Check toolName in root
-	p = filepath.Join(verDir, toolName)
-	if _, err := os.Stat(p); err == nil {
-		return p
-	}
-	// Check toolName.exe in root
-	p = filepath.Join(verDir, toolName+".exe")
-	if _, err := os.Stat(p); err == nil {
-		return p
-	}
-
 	return ""
 }
 
@@ -187,50 +179,6 @@ func readToolVersion(path, toolName string) string {
 
 func sortVersions(versions []string) {
 	sort.Slice(versions, func(i, j int) bool {
-		return compareVersions(versions[i], versions[j]) < 0
+		return semver.Parse(versions[i]).Less(semver.Parse(versions[j]))
 	})
-}
-
-func compareVersions(v1, v2 string) int {
-	p1 := parseVersion(v1)
-	p2 := parseVersion(v2)
-	l := min(len(p2), len(p1))
-	for k := 0; k < l; k++ {
-		if p1[k] < p2[k] {
-			return -1
-		}
-		if p1[k] > p2[k] {
-			return 1
-		}
-	}
-	if len(p1) < len(p2) {
-		return -1
-	}
-	if len(p1) > len(p2) {
-		return 1
-	}
-	return 0
-}
-
-func parseVersion(v string) []int {
-	v = strings.TrimPrefix(v, "v")
-	parts := strings.Split(v, ".")
-	var nums []int
-	for _, part := range parts {
-		numPart := ""
-		for _, r := range part {
-			if r >= '0' && r <= '9' {
-				numPart += string(r)
-			} else {
-				break
-			}
-		}
-		if numPart == "" {
-			nums = append(nums, 0)
-		} else {
-			n, _ := strconv.Atoi(numPart)
-			nums = append(nums, n)
-		}
-	}
-	return nums
 }

--- a/pkg/tool/resolver.go
+++ b/pkg/tool/resolver.go
@@ -2,6 +2,7 @@ package tool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,15 @@ import (
 	parsespec "workspaced/pkg/parse/spec"
 	"workspaced/pkg/taskgroup"
 	"workspaced/pkg/tool/backend"
+)
+
+var (
+	// ErrNoVersionsFound is returned when a tool has no available versions upstream.
+	ErrNoVersionsFound = errors.New("no versions found")
+	// ErrToolDirNotFound is returned when a tool's version directory doesn't exist.
+	ErrToolDirNotFound = errors.New("tool directory not found")
+	// ErrBinaryNotFound is returned when the binary is not found within a tool's install dir.
+	ErrBinaryNotFound = errors.New("binary not found")
 )
 
 // EnsureInstalled resolves the binary path for a requested tool, triggering a dynamic
@@ -146,23 +156,14 @@ func (m *Manager) ResolveBinary(spec parsespec.Spec, cmdName string) (string, er
 	versionDir := filepath.Join(m.toolsDir, spec.Dir(), normalizedVersion)
 
 	if _, err := os.Stat(versionDir); os.IsNotExist(err) {
-		return "", fmt.Errorf("tool directory not found: %s", versionDir)
+		return "", fmt.Errorf("%w: %s", ErrToolDirNotFound, versionDir)
 	}
 
-	candidates := []string{
-		filepath.Join(versionDir, "bin", cmdName),
-		filepath.Join(versionDir, "bin", cmdName+".exe"),
-		filepath.Join(versionDir, cmdName),
-		filepath.Join(versionDir, cmdName+".exe"),
+	if binPath := FindBinary(versionDir, cmdName); binPath != "" {
+		return binPath, nil
 	}
 
-	for _, path := range candidates {
-		if _, err := os.Stat(path); err == nil {
-			return path, nil
-		}
-	}
-
-	return "", fmt.Errorf("binary %q not found in %s", cmdName, versionDir)
+	return "", fmt.Errorf("%w: %q in %s", ErrBinaryNotFound, cmdName, versionDir)
 }
 
 // ResolveLatestVersion delegates to the underlying tool provider to query the remote
@@ -185,7 +186,7 @@ func (m *Manager) ResolveLatestVersion(ctx context.Context, spec parsespec.Spec)
 	}
 
 	if len(versions) == 0 {
-		return "", fmt.Errorf("no versions found")
+		return "", ErrNoVersionsFound
 	}
 
 	// We assume the first one is relevant (often latest from the provider).

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -6,9 +6,15 @@
 package tool
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"workspaced/pkg/tool/backend"
+)
+
+var (
+	// ErrBackendNotFound is returned when a requested tool backend is not registered.
+	ErrBackendNotFound = errors.New("tool backend not found")
 )
 
 var (
@@ -31,23 +37,7 @@ func Get(id string) (backend.Backend, error) {
 	defer mu.RUnlock()
 	b, ok := backends[id]
 	if !ok {
-		return nil, fmt.Errorf("tool backend not found: %s", id)
+		return nil, fmt.Errorf("%w: %s", ErrBackendNotFound, id)
 	}
 	return b, nil
-}
-
-// --- Transitional shims ---
-// These keep old call sites compiling while we migrate to the new Register/Get names
-// and the Backend interface. They will be removed after migration.
-
-func RegisterProvider(p backend.Backend) {
-	// During transition the concrete backends no longer have ID(), so we cannot
-	// recover the id here. Call sites in inits are being updated to use Register directly.
-	// This shim is a no-op placeholder to avoid immediate compile errors in case
-	// something still calls it; real registration now happens via Register(id, b).
-	_ = p
-}
-
-func GetProvider(id string) (backend.Backend, error) {
-	return Get(id)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,27 +2,6 @@ package types
 
 import "encoding/json"
 
-// ContextKey is a distinct string type for context values to prevent key collisions.
-type ContextKey string
-
-const (
-	// DaemonModeKey flags whether the application is running as a long-lived daemon.
-	DaemonModeKey ContextKey = "daemon_mode"
-	// EnvKey stores the environment variables (slice of "KEY=VALUE" strings)
-	// to be injected into subprocesses spawned by the handler.
-	EnvKey ContextKey = "env"
-	// LoggerKey stores the *slog.Logger instance, allowing contextual logging
-	// (e.g., with request IDs) throughout the request lifecycle.
-	LoggerKey ContextKey = "logger"
-	// StdoutKey stores an io.Writer for capturing standard output from subprocesses,
-	// typically redirected to the client's response stream.
-	StdoutKey ContextKey = "stdout"
-	// StderrKey stores an io.Writer for capturing standard error from subprocesses.
-	StderrKey ContextKey = "stderr"
-	// DBKey stores the database connection.
-	DBKey ContextKey = "db"
-)
-
 // SudoCommand defines a privileged command request.
 // It aggregates execution context (cwd, env) and a timestamp for validity checks.
 type SudoCommand struct {


### PR DESCRIPTION
You are a codebase tech debt specialist. You are well versed in the best practices and design patterns of the Go programming language. You know that the best approach is the simplest one and that many bugs are uncovered when the mess is redone in a simpler way.

You are tasked to refactor the structure of this codebase.

- Find duplicated logic and abstract it away into utility functions and types. If necessary, move them to a utils package.
- Refactor logic that could be pure functions into pure functions. Actual pure functions, without side effects. And add table tests for them.
- Find places where errors are defined inline using errors.New or fmt.Errorf without %w and an error reference. errors.Is should be easy and first class citizen for error checking.
- Make sure every error returned is either a stdlib error, a error defined as errors.New inside a var block or a fmt.Errorf with %w that references the other two error situations
- The project is full of structures formed by interface/implementation, like the driver system, make sure errors general to the interface part are defined on the interface package and errors specific to a implementation be defined in the implementation package.
- On context value passing, each context With/Get must happen in a context.go on the same package the thing being passed down is.
- Prelude files are automatically generated by the tricks implemented in the only main package outside cmd. Don't deal with prelude files manually.
- Make sure the terminology in README is used properly for naming things across the codebase
- Make sure no abbreviations are being done in the name of any item unless it's redundante with the name of the type of the value or it's a common convention (ctx for Context, t for testing.T, i, j and k for loops, etc)
- Use gopls subcommands where possible for deterministic refactorings instead of keeping track of everything manually
- Do a audit on how packages are structured and do changes that make sense based on the other restrictions, moving trivial packages into packages in utils is one suggestion. Just have common sense on how to reduce the bandwidth to understand the moves, like a hierarchy package structure based on a criteria that you can study better as this project has a handful of facets already. Just take into account that simple is often better.
- At the end, tell about each high level decision you did, like the packages you created, the duplicated logic you abstracted away, the terminology fixes, the kind of changes you did to solve the error requisites and how you made the system more clean with actual proof, not just claims.

You are not allowed to use the Internet during the class and are not allowed to stop until you satisfy all the restrictions.

I recommend you look package by package then checking each of the goal topics for that package instead of going from the goal topics to the packages, at least in a first round. All packages have to be checked, no exceptions.

I know this has a relevant scope and I expect a really relevant effort, without excuses and unbased claims.

You are a codebase tech debt specialist. You are well versed in the best practices and design patterns of the Go programming language. You know that the best approach is the simplest one and that many bugs are uncovered when the mess is redone in a simpler way.

You are tasked to refactor the structure of this codebase.

- Find duplicated logic and abstract it away into utility functions and types. If necessary, move them to a utils package.
- Refactor logic that could be pure functions into pure functions. Actual pure functions, without side effects. And add table tests for them.
- Find places where errors are defined inline using errors.New or fmt.Errorf without %w and an error reference. errors.Is should be easy and first class citizen for error checking.
- Make sure every error returned is either a stdlib error, a error defined as errors.New inside a var block or a fmt.Errorf with %w that references the other two error situations
- The project is full of structures formed by interface/implementation, like the driver system, make sure errors general to the interface part are defined on the interface package and errors specific to a implementation be defined in the implementation package.
- On context value passing, each context With/Get must happen in a context.go on the same package the thing being passed down is.
- Prelude files are automatically generated by the tricks implemented in the only main package outside cmd. Don't deal with prelude files manually.
- Make sure the terminology in README is used properly for naming things across the codebase
- Make sure no abbreviations are being done in the name of any item unless it's redundante with the name of the type of the value or it's a common convention (ctx for Context, t for testing.T, i, j and k for loops, etc)
- Use gopls subcommands where possible for deterministic refactorings instead of keeping track of everything manually
- Do a audit on how packages are structured and do changes that make sense based on the other restrictions, moving trivial packages into packages in utils is one suggestion. Just have common sense on how to reduce the bandwidth to understand the moves, like a hierarchy package structure based on a criteria that you can study better as this project has a handful of facets already. Just take into account that simple is often better.
- At the end, tell about each high level decision you did, like the packages you created, the duplicated logic you abstracted away, the terminology fixes, the kind of changes you did to solve the error requisites and how you made the system more clean with actual proof, not just claims.

You are not allowed to use the Internet during the class and are not allowed to stop until you satisfy all the restrictions.

I recommend you look package by package then checking each of the goal topics for that package instead of going from the goal topics to the packages, at least in a first round. All packages have to be checked, no exceptions.

I know this has a relevant scope and I expect a really relevant effort, without excuses and unbased claims.

Signed-off-by: lucasew <lucas59356@gmail.com>
