### PR TITLE
🧹 Janitor: handle hyprland activeworkspace errors

### DIFF
--- a/pkg/driver/wm/hyprland/driver.go
+++ b/pkg/driver/wm/hyprland/driver.go
@@ -96,11 +96,16 @@ func (d *Driver) GetWorkspaces(ctx context.Context) ([]api.Workspace, error) {
 		return nil, fmt.Errorf("%w: %w", dapi.ErrIPC, err)
 	}
 
-	activeWSOut, _ := execdriver.MustRun(ctx, "hyprctl", "activeworkspace", "-j").Output()
+	activeWSOut, err := execdriver.MustRun(ctx, "hyprctl", "activeworkspace", "-j").Output()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", dapi.ErrIPC, err)
+	}
 	var activeWS struct {
 		Name string `json:"name"`
 	}
-	_ = json.Unmarshal(activeWSOut, &activeWS)
+	if err := json.Unmarshal(activeWSOut, &activeWS); err != nil {
+		return nil, fmt.Errorf("%w: %w", dapi.ErrIPC, err)
+	}
 
 	var result []api.Workspace
 	for _, w := range workspaces {


### PR DESCRIPTION
## Problem
In `GetWorkspaces`, after correctly handling the `workspaces -j` call, errors for `activeworkspace` were ignored:

- `Output()` error discarded
- `json.Unmarshal` error discarded

That left `Focused` flags silently wrong (all false) when hyprctl failed or returned bad JSON.

## Fix
- Check `Output()` error; wrap with `dapi.ErrIPC` like the workspaces call.
- Check `json.Unmarshal` error the same way.
- Successful behavior unchanged.

## Verification
- `go test ./pkg/driver/wm/...`
- `go build -o /dev/null ./pkg/driver/wm/hyprland/`