### PR TITLE
🧹 Janitor: log gtk-update-icon-cache failures

### DIFF
--- a/internal/icons/theme_generate_engine.go
+++ b/internal/icons/theme_generate_engine.go
@@ -205,9 +205,12 @@ func runThemeGenerateEngine(ctx context.Context, opts ThemeGenerateOptions, inpu
 	}
 
 	if opts.UpdateCache && execdriver.IsBinaryAvailable(ctx, "gtk-update-icon-cache") {
+		logger := logging.GetLogger(ctx)
 		cacheCmd, err := execdriver.Run(ctx, "gtk-update-icon-cache", "-f", "-q", outputDir)
-		if err == nil {
-			_ = cacheCmd.Run()
+		if err != nil {
+			logger.Warn("failed to prepare gtk-update-icon-cache", "dir", outputDir, "error", err)
+		} else if err := cacheCmd.Run(); err != nil {
+			logger.Warn("gtk-update-icon-cache failed", "dir", outputDir, "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Problem

When updating the GTK icon cache after theme generation, both `execdriver.Run` prepare failures and `cacheCmd.Run()` failures were silently discarded. Cache update is best-effort, but operators had no signal that the theme may lack an updated cache.

## Fix

Log a warning via `logging.GetLogger(ctx).Warn(...)` on prepare or run failure. Theme generation still succeeds (behavior-preserving best-effort). Success path unchanged.

## Verification

```
go test ./internal/icons/...
```