### PR TITLE
🧹 Janitor: stop daemon from mutating slog.Default

### DIFF
--- a/cmd/workspaced/daemon/daemon.go
+++ b/cmd/workspaced/daemon/daemon.go
@@ -110,7 +110,6 @@ func RunDaemon(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	slog.SetDefault(slog.New(logging.NewPlainHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	logger := logging.GetLogger(ctx)
 	logger.Info("daemon starting", "pid", os.Getpid())
 
@@ -363,7 +362,7 @@ func handleRequest(ctx context.Context, req types.Request, outCh chan types.Stre
 
 	handler := &logging.ChannelLogHandler{
 		Out:    outCh,
-		Parent: slog.Default().Handler(),
+		Parent: logger.Handler(),
 		Ctx:    ctx,
 	}
 	reqLogger := slog.New(handler)


### PR DESCRIPTION
## Problem
Daemon startup called `slog.SetDefault(...)`, mutating the process-wide slog default. Request handling then used `slog.Default().Handler()` as `ChannelLogHandler.Parent`, coupling streamed request logs to that global.

## Fix
- Drop `slog.SetDefault`; keep using `logging.GetLogger(ctx)` already on the command context.
- Set `ChannelLogHandler.Parent` from that context logger's handler so request log streaming still tees to the daemon logger without touching globals.

## Verified
- `go test ./cmd/workspaced/daemon/...`
- `go build -o /dev/null ./cmd/workspaced/`

Assumption: root CLI already injects a logger on `ctx` before `RunDaemon` (existing bootstrap in `cmd/workspaced/root.go`).