### PR TITLE
🧹 Janitor: use logging.Close for camera capture file

### DIFF
--- a/cmd/workspaced/driver/camera/capture.go
+++ b/cmd/workspaced/driver/camera/capture.go
@@ -13,6 +13,7 @@ import (
 
 	"workspaced/pkg/driver"
 	cameraapi "workspaced/pkg/driver/camera"
+	"workspaced/pkg/logging"
 
 	"github.com/spf13/cobra"
 )
@@ -78,10 +79,7 @@ func capture(cmd *cobra.Command, id, outPath string) error {
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		_ = out.Close()
-	}()
+	defer logging.Close(cmd.Context(), out, "path", outPath)
 	if err := png.Encode(out, img); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

After successfully creating the PNG output file in camera capture, close was ignored:

```go
defer func() {
    _ = out.Close()
}()
```

Teardown errors were silent. The project pattern (see Jules PR #140 and `pkg/logging.Close`) is to report close failures via `logging.Close` so they are visible without failing the happy path after a successful write.

## Fix

- Replace the ignored close with `defer logging.Close(cmd.Context(), out, "path", outPath)` after successful `os.Create`.
- Import `workspaced/pkg/logging`.
- No changes to capture logic, camera selection, or CLI flags.

## Verification

- `go test ./cmd/workspaced/driver/camera/...` (no test files; package compiles)
- `go build -o /dev/null ./cmd/workspaced/`