### PR TITLE
🧹 Janitor: surface configcue input resolve errors

### DIFF
--- a/internal/configcue/loader.go
+++ b/internal/configcue/loader.go
@@ -849,8 +849,13 @@ func resolveRuntimeInputs(configValue cue.Value, paths []string, discovered []La
 		Version string `json:"version"`
 	}
 	cfgInputs := map[string]inputCfg{}
-	tmp, _ := json.Marshal(inputsRaw)
-	_ = json.Unmarshal(tmp, &cfgInputs)
+	tmp, err := json.Marshal(inputsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inputs for resolution: %w", err)
+	}
+	if err := json.Unmarshal(tmp, &cfgInputs); err != nil {
+		return nil, fmt.Errorf("decode inputs for resolution: %w", err)
+	}
 
 	modulesBaseDir := resolvedSelfModulesBase(paths, discovered)
 	workspaceRoot := filepath.Dir(modulesBaseDir)

--- a/internal/configcue/loader_test.go
+++ b/internal/configcue/loader_test.go
@@ -1,0 +1,69 @@
+package configcue
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+)
+
+func TestResolveRuntimeInputs_valid(t *testing.T) {
+	cueCtx := cuecontext.New()
+	v := cueCtx.CompileString(`{
+		inputs: {
+			self: {from: "self"}
+			localmod: {from: "local:./modules/foo"}
+			gh: {from: "github:org/repo", version: "v1.0.0"}
+		}
+	}`)
+	if err := v.Err(); err != nil {
+		t.Fatalf("compile cue: %v", err)
+	}
+
+	repoCue := filepath.Join(t.TempDir(), "workspaced.cue")
+	out, err := resolveRuntimeInputs(v, []string{repoCue}, []Layer{{Name: "repo", Path: repoCue}})
+	if err != nil {
+		t.Fatalf("resolveRuntimeInputs: %v", err)
+	}
+	if got := out["self"]["path"]; got == nil || got == "" {
+		t.Fatalf("self path missing: %#v", out["self"])
+	}
+	if got, ok := out["localmod"]["path"].(string); !ok || !strings.HasSuffix(filepath.Clean(got), filepath.Join("modules", "foo")) {
+		t.Fatalf("localmod path = %#v", out["localmod"])
+	}
+	if got, ok := out["gh"]["path"].(string); !ok || !strings.Contains(got, filepath.Join(".cache", "workspaced", "sources", "github")) {
+		t.Fatalf("gh path = %#v", out["gh"])
+	}
+}
+
+func TestResolveRuntimeInputs_decodeError(t *testing.T) {
+	cueCtx := cuecontext.New()
+	// Shape that JSON-decodes but cannot map into inputCfg (string instead of object).
+	v := cueCtx.CompileString(`{inputs: {bad: "not-an-object"}}`)
+	if err := v.Err(); err != nil {
+		t.Fatalf("compile cue: %v", err)
+	}
+	_, err := resolveRuntimeInputs(v, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for non-object input")
+	}
+	if !strings.Contains(err.Error(), "decode inputs for resolution") {
+		t.Fatalf("error = %v, want decode inputs for resolution", err)
+	}
+}
+
+func TestResolveRuntimeInputs_empty(t *testing.T) {
+	cueCtx := cuecontext.New()
+	v := cueCtx.CompileString(`{modules: {}}`)
+	if err := v.Err(); err != nil {
+		t.Fatalf("compile cue: %v", err)
+	}
+	out, err := resolveRuntimeInputs(v, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveRuntimeInputs: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("out = %#v, want nil", out)
+	}
+}


### PR DESCRIPTION
## Problem

In `resolveRuntimeInputs`, marshal/unmarshal of configured inputs discarded errors:

```go
tmp, _ := json.Marshal(inputsRaw)
_ = json.Unmarshal(tmp, &cfgInputs)
```

If the inputs shape was unexpected, resolution continued with empty `cfgInputs` and could silently drop configured inputs.

## Fix

- Propagate `json.Marshal` / `json.Unmarshal` errors with local-style wrapping (`marshal inputs for resolution`, `decode inputs for resolution`).
- Add small unit tests for valid resolution, empty inputs, and decode failure on bad shape.
- Successful resolution behavior for valid configs is unchanged.

## Verification

```
go test ./internal/configcue/... -count=1 -v
```