### PR TITLE
🧹 Janitor: check rsync scanner errors and close pipe

### DIFF
--- a/internal/backup/action_rsync.go
+++ b/internal/backup/action_rsync.go
@@ -50,9 +50,8 @@ func (a RsyncAction) Run(ctx context.Context, n *notification.Notification) erro
 	}
 
 	// Scanner goroutine feeds the notification with live rsync status lines.
-	scanDone := make(chan struct{})
+	scanDone := make(chan error, 1)
 	go func() {
-		defer close(scanDone)
 		scanner := bufio.NewScanner(pr)
 		lastUpdate := time.Now()
 		for scanner.Scan() {
@@ -68,13 +67,14 @@ func (a RsyncAction) Run(ctx context.Context, n *notification.Notification) erro
 				lastUpdate = time.Now()
 			}
 		}
+		scanDone <- scanner.Err()
 	}()
 
 	err := rsync.Sync(ctx, a.Src, a.Dst, opts)
 
 	// Close write side so the scanner goroutine drains and exits.
-	pw.Close()
-	<-scanDone
+	logging.Close(ctx, pw)
+	scanErr := <-scanDone
 
-	return err
+	return errors.Join(err, scanErr)
 }


### PR DESCRIPTION
## Problem

After `rsync.Sync`, the write side of the notification pipe was closed with a bare `pw.Close()` (error discarded). The scanner goroutine never checked `scanner.Err()`, so pipe/read failures were dropped silently.

## Change

- Pipe the scanner's `scanner.Err()` back on the done channel and `errors.Join` it with the rsync result (rsync error stays primary; scan error is not masked either).
- Close the write end with `logging.Close(ctx, pw)`, same pattern as the clipboard drivers.

## Verified

- `go test ./internal/backup/...`