### PR TITLE
🧹 Janitor: safe type assertions in media dbus driver

### DIFF
--- a/pkg/driver/media/dbus/driver.go
+++ b/pkg/driver/media/dbus/driver.go
@@ -82,9 +82,13 @@ func (d *Driver) getBestPlayer(ctx context.Context) (dbus.BusObject, string, err
 		if err != nil {
 			continue
 		}
+		status, ok := statusVar.Value().(string)
+		if !ok {
+			continue
+		}
 		infos = append(infos, playerInfo{
 			name:   p,
-			status: statusVar.Value().(string),
+			status: status,
 			obj:    obj,
 		})
 	}
@@ -129,20 +133,29 @@ func (d *Driver) GetMetadata(ctx context.Context) (*media.Metadata, error) {
 	if err != nil {
 		return nil, err
 	}
+	status, ok := statusVar.Value().(string)
+	if !ok {
+		return nil, fmt.Errorf("playback status: unexpected type %T", statusVar.Value())
+	}
 
 	metadataVar, err := obj.GetProperty("org.mpris.MediaPlayer2.Player.Metadata")
 	if err != nil {
 		return nil, err
 	}
 
-	m := metadataVar.Value().(map[string]dbus.Variant)
+	m, ok := metadataVar.Value().(map[string]dbus.Variant)
+	if !ok {
+		return nil, fmt.Errorf("metadata: unexpected type %T", metadataVar.Value())
+	}
 	res := &media.Metadata{
 		Player: name,
-		Status: media.PlaybackStatus(statusVar.Value().(string)),
+		Status: media.PlaybackStatus(status),
 	}
 
 	if v, ok := m["xesam:title"]; ok {
-		res.Title = v.Value().(string)
+		if title, ok := v.Value().(string); ok {
+			res.Title = title
+		}
 	}
 	if v, ok := m["xesam:artist"]; ok {
 		switch val := v.Value().(type) {
@@ -161,7 +174,9 @@ func (d *Driver) GetMetadata(ctx context.Context) (*media.Metadata, error) {
 		}
 	}
 	if v, ok := m["mpris:artUrl"]; ok {
-		res.ArtUrl = v.Value().(string)
+		if artUrl, ok := v.Value().(string); ok {
+			res.ArtUrl = artUrl
+		}
 	}
 	if v, ok := m["mpris:length"]; ok {
 		switch val := v.Value().(type) {
@@ -202,10 +217,14 @@ func (d *Driver) Watch(ctx context.Context, callback func(*media.Metadata)) erro
 			if len(signal.Body) < 2 {
 				continue
 			}
-			if signal.Body[0].(string) != "org.mpris.MediaPlayer2.Player" {
+			iface, ok := signal.Body[0].(string)
+			if !ok || iface != "org.mpris.MediaPlayer2.Player" {
 				continue
 			}
-			changed := signal.Body[1].(map[string]dbus.Variant)
+			changed, ok := signal.Body[1].(map[string]dbus.Variant)
+			if !ok {
+				continue
+			}
 			if _, ok := changed["Metadata"]; ok {
 				meta, err := d.GetMetadata(ctx)
 				if err == nil {


### PR DESCRIPTION
## Summary

MPRIS D-Bus properties were decoded with single-value type assertions (`Value().(string)`, `.(map[string]dbus.Variant)`). A player that returns an unexpected variant type panics the process.

This matches the existing artist type switch: two-value asserts / continue on bad values.

- `getBestPlayer`: skip players whose `PlaybackStatus` is not a string
- `GetMetadata`: error only if status or the metadata map itself is wrong type; skip title/artUrl when not strings
- `Watch`: skip signals with unexpected body types instead of panicking

## Test plan

- [x] `go test ./pkg/driver/media/...`
- [x] `go build ./pkg/driver/media/dbus/...`
- [x] `go vet ./pkg/driver/media/dbus/...`

Finding: `media-dbus-assert`