### PR TITLE
🧹 Janitor: surface mise.toml scanner errors in tool resolution

### DIFF
--- a/internal/tool/resolution/resolver.go
+++ b/internal/tool/resolution/resolver.go
@@ -24,7 +24,10 @@ func NewResolver(toolsDir string) *Resolver {
 }
 
 func (r *Resolver) Resolve(ctx context.Context, toolName string) (string, error) {
-	version := r.resolveVersion(ctx, toolName)
+	version, err := r.resolveVersion(ctx, toolName)
+	if err != nil {
+		return "", err
+	}
 
 	// Search for the tool binary in installed packages
 	entries, err := os.ReadDir(r.toolsDir)
@@ -106,33 +109,41 @@ func (r *Resolver) checkBin(verDir, toolName string) string {
 	return ""
 }
 
-func (r *Resolver) resolveVersion(ctx context.Context, toolName string) string {
+func (r *Resolver) resolveVersion(ctx context.Context, toolName string) (string, error) {
 	// 1. .tool-versions
-	if v := r.findInToolVersions(ctx, toolName); v != "" {
-		return v
+	v, err := r.findInToolVersions(ctx, toolName)
+	if err != nil {
+		return "", err
+	}
+	if v != "" {
+		return v, nil
 	}
 
 	// 2. Env var: WORKSPACED_TOOL_VERSION
 	envKey := "WORKSPACED_" + strings.ToUpper(strings.ReplaceAll(toolName, "-", "_")) + "_VERSION"
 	if v := os.Getenv(envKey); v != "" {
-		return v
+		return v, nil
 	}
 
 	// 3. Fallback
-	return "latest"
+	return "latest", nil
 }
 
-func (r *Resolver) findInToolVersions(ctx context.Context, toolName string) string {
+func (r *Resolver) findInToolVersions(ctx context.Context, toolName string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return ""
+		return "", nil
 	}
 
 	for {
 		p := filepath.Join(cwd, ".tool-versions")
 		if _, err := os.Stat(p); err == nil {
-			if v := readToolVersion(ctx, p, toolName); v != "" {
-				return v
+			v, err := readToolVersion(ctx, p, toolName)
+			if err != nil {
+				return "", err
+			}
+			if v != "" {
+				return v, nil
 			}
 		}
 
@@ -147,19 +158,23 @@ func (r *Resolver) findInToolVersions(ctx context.Context, toolName string) stri
 	if err == nil {
 		p := filepath.Join(home, ".config", "workspaced", ".tool-versions")
 		if _, err := os.Stat(p); err == nil {
-			if v := readToolVersion(ctx, p, toolName); v != "" {
-				return v
+			v, err := readToolVersion(ctx, p, toolName)
+			if err != nil {
+				return "", err
+			}
+			if v != "" {
+				return v, nil
 			}
 		}
 	}
 
-	return ""
+	return "", nil
 }
 
-func readToolVersion(ctx context.Context, path, toolName string) string {
+func readToolVersion(ctx context.Context, path, toolName string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer logging.Close(ctx, f)
 
@@ -171,10 +186,13 @@ func readToolVersion(ctx context.Context, path, toolName string) string {
 		}
 		parts := strings.Fields(line)
 		if len(parts) >= 2 && parts[0] == toolName {
-			return parts[1]
+			return parts[1], nil
 		}
 	}
-	return ""
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan %s: %w", path, err)
+	}
+	return "", nil
 }
 
 func sortVersions(versions []string) {

--- a/internal/tool/resolution/resolver_test.go
+++ b/internal/tool/resolution/resolver_test.go
@@ -1,0 +1,74 @@
+package resolution
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"workspaced/pkg/logging"
+)
+
+func TestReadToolVersion_found(t *testing.T) {
+	ctx := logging.NewWriterContext(t.Output())
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tool-versions")
+	if err := os.WriteFile(path, []byte("# comment\n\ngo 1.22.0\ndeno 1.40.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readToolVersion(ctx, path, "deno")
+	if err != nil {
+		t.Fatalf("readToolVersion: %v", err)
+	}
+	if got != "1.40.0" {
+		t.Fatalf("got %q, want 1.40.0", got)
+	}
+}
+
+func TestReadToolVersion_missing(t *testing.T) {
+	ctx := logging.NewWriterContext(t.Output())
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tool-versions")
+	if err := os.WriteFile(path, []byte("go 1.22.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readToolVersion(ctx, path, "deno")
+	if err != nil {
+		t.Fatalf("readToolVersion: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestReadToolVersion_tokenTooLong(t *testing.T) {
+	ctx := logging.NewWriterContext(t.Output())
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tool-versions")
+	// bufio.Scanner default max token size is 64KiB; one line longer than that fails.
+	longLine := strings.Repeat("x", 70*1024) + "\n"
+	if err := os.WriteFile(path, []byte(longLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readToolVersion(ctx, path, "deno")
+	if err == nil {
+		t.Fatal("expected scan error for oversized line")
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	if !strings.Contains(err.Error(), "scan") {
+		t.Fatalf("error = %v, want scan context", err)
+	}
+}
+
+func TestReadToolVersion_openMissing(t *testing.T) {
+	ctx := logging.NewWriterContext(t.Output())
+	_, err := readToolVersion(ctx, filepath.Join(t.TempDir(), "nope"), "deno")
+	if err == nil {
+		t.Fatal("expected open error")
+	}
+}


### PR DESCRIPTION
## Problem

`readToolVersion` walked `.tool-versions` with `bufio.Scanner` and never checked `scanner.Err()`. On I/O failure or a token longer than the scanner limit, it returned `""` as if the tool simply was not listed, so resolution fell through to `"latest"`.

## Fix

- `readToolVersion` now returns `(string, error)` and wraps `scanner.Err()` (and open failures).
- Errors propagate through `findInToolVersions` / `resolveVersion` into `Resolve` so callers stop instead of picking the wrong version.
- Package tests cover found/missing tools, open failure, and oversized-line scan failure.

## Verify

```
go test ./internal/tool/resolution/...
```

Finding: `tool-version-scanner`