### PR TITLE
🧹 Janitor: surface nodejs SHASUM and request errors

### DIFF
--- a/internal/tool/backend/catalog/applications/nodejs.go
+++ b/internal/tool/backend/catalog/applications/nodejs.go
@@ -64,7 +64,10 @@ func (t *nodejsTool) ListArtifacts(ctx context.Context, version string) ([]backe
 	url := fmt.Sprintf("https://nodejs.org/dist/%s/%s", v, filename)
 
 	// Fetch SHASUMS256.txt so we can attach hash and use fetchurl backend.
-	sums, _ := t.fetchShasums(ctx, v)
+	sums, err := t.fetchShasums(ctx, v)
+	if err != nil {
+		return nil, err
+	}
 	hash := ""
 	if h, ok := sums[filename]; ok && h != "" {
 		hash = "sha256:" + h
@@ -103,7 +106,10 @@ func (t *nodejsTool) listVersions(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := hc.Client().Do(req)
 	if err != nil {
 		return nil, err
@@ -132,7 +138,10 @@ func (t *nodejsTool) fetchShasums(ctx context.Context, ver string) (map[string]s
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := hc.Client().Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`ListArtifacts` called `fetchShasums` and discarded the error. When `SHASUMS256.txt` failed to download or parse, Node.js artifacts still went out with an empty `Hash`, so the fetchurl path skipped integrity checks.

`http.NewRequestWithContext` errors were also discarded in `listVersions` and `fetchShasums` (`req, _ :=`), which can mishandle a nil request if construction fails. Other catalog tools (`cmake`, `claude_code`) already check these.

## Change

In `internal/tool/backend/catalog/applications/nodejs.go` only:

- Propagate `fetchShasums` errors from `ListArtifacts` (fail instead of emitting hash-less artifacts).
- Return `NewRequestWithContext` errors from `listVersions` and `fetchShasums`.

## Behavior note

Install / lock resolution is stricter when the SHASUM fetch fails: listing artifacts errors instead of continuing without a hash. That is intentional so integrity is not optional when the shasum source is unreachable.

## Verified

- `go test ./internal/tool/backend/catalog/...`
- `go build ./internal/tool/backend/catalog/applications/` and `./cmd/workspaced/`