### PR TITLE
🧹 Janitor: check UserHomeDir when expanding scanner baseDir

### DIFF
--- a/internal/source/plugin_scanner.go
+++ b/internal/source/plugin_scanner.go
@@ -46,7 +46,10 @@ func NewScannerPlugin(cfg ScannerConfig) (*ScannerPlugin, error) {
 	// Expand paths
 	baseDir := os.ExpandEnv(cfg.BaseDir)
 	if strings.HasPrefix(baseDir, "~/") {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
 		baseDir = filepath.Join(home, baseDir[2:])
 	}
 


### PR DESCRIPTION
## Summary
- Check `os.UserHomeDir()` error when expanding `~/` in scanner `BaseDir` (same pattern as `TargetBase` default).
- Avoids silent empty-home expansion that produced relative baseDir paths and confusing `Stat` failures.

## Finding
- **id:** `scanner-homedir`
- **taxonomy:** Ignored errors / inconsistent wording
- **file:** `internal/source/plugin_scanner.go`

## Test plan
- [x] `go test ./internal/source/...`