### PR TITLE
🧹 Janitor: check HTTP request construction in go/flutter tools

### DIFF
--- a/internal/tool/backend/catalog/applications/flutter.go
+++ b/internal/tool/backend/catalog/applications/flutter.go
@@ -53,7 +53,10 @@ func (t *flutterTool) ListArtifacts(ctx context.Context, version string) ([]back
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := hc.Client().Do(req)
 	if err != nil {
 		return nil, err
@@ -122,7 +125,10 @@ func (t *flutterTool) listVersions(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := hc.Client().Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/tool/backend/catalog/applications/go.go
+++ b/internal/tool/backend/catalog/applications/go.go
@@ -51,7 +51,10 @@ func (t *goTool) ListArtifacts(ctx context.Context, version string) ([]backend.A
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := hc.Client().Do(req)
 	if err != nil {
 		return nil, err
@@ -126,7 +129,10 @@ func (t *goTool) listVersions(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := hc.Client().Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Check and return `http.NewRequestWithContext` errors in the golang and flutter catalog tools (all four call sites).
- Same pattern as #154 (nodejs) and existing claude_code/cmake tooling.

**Finding:** `catalog-http-req-errs`  
**Paths:** `internal/tool/backend/catalog/applications/go.go`, `flutter.go`

## Test plan

- [x] `go test ./internal/tool/backend/catalog/...`