### PR TITLE
🧹 Janitor: handle GitHub API error body read failures

### DIFF
--- a/internal/tool/backend/github/backend.go
+++ b/internal/tool/backend/github/backend.go
@@ -99,15 +99,7 @@ func (p *Backend) ListVersions(ctx context.Context, pkg backend.PackageConfig) (
 	defer logging.Close(ctx, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		msg := strings.TrimSpace(string(body))
-		if resp.StatusCode == http.StatusForbidden && strings.Contains(msg, "rate limit") {
-			return nil, fmt.Errorf("github api rate limit exceeded for %s (consider setting GITHUB_TOKEN or logging in with 'gh auth login'): %s: %w", url, resp.Status, ErrAPIError)
-		}
-		if msg != "" {
-			return nil, fmt.Errorf("github api error for %s: %s: %s: %w", url, resp.Status, msg, ErrAPIError)
-		}
-		return nil, fmt.Errorf("github api error for %s: %s: %w", url, resp.Status, ErrAPIError)
+		return nil, apiErrorFromResponse(url, resp)
 	}
 
 	var releases []release
@@ -142,6 +134,24 @@ func releaseTags(releases []release, includePrerelease bool) []string {
 	return versions
 }
 
+// apiErrorFromResponse turns a non-OK GitHub API response into ErrAPIError.
+// When the body is readable, rate-limit wording is detected; if ReadAll fails,
+// fall back to a status-only message that includes the read error.
+func apiErrorFromResponse(requestURL string, resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("github api error for %s: %s (reading body: %v): %w", requestURL, resp.Status, err, ErrAPIError)
+	}
+	msg := strings.TrimSpace(string(body))
+	if resp.StatusCode == http.StatusForbidden && strings.Contains(msg, "rate limit") {
+		return fmt.Errorf("github api rate limit exceeded for %s (consider setting GITHUB_TOKEN or logging in with 'gh auth login'): %s: %w", requestURL, resp.Status, ErrAPIError)
+	}
+	if msg != "" {
+		return fmt.Errorf("github api error for %s: %s: %s: %w", requestURL, resp.Status, msg, ErrAPIError)
+	}
+	return fmt.Errorf("github api error for %s: %s: %w", requestURL, resp.Status, ErrAPIError)
+}
+
 func (p *Backend) GetArtifacts(ctx context.Context, pkg backend.PackageConfig, version string) ([]backend.Artifact, error) {
 	logger := logging.GetLogger(ctx)
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", pkg.Repo, version)
@@ -172,15 +182,7 @@ func (p *Backend) GetArtifacts(ctx context.Context, pkg backend.PackageConfig, v
 	defer logging.Close(ctx, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		msg := strings.TrimSpace(string(body))
-		if resp.StatusCode == http.StatusForbidden && strings.Contains(msg, "rate limit") {
-			return nil, fmt.Errorf("github api rate limit exceeded for %s (consider setting GITHUB_TOKEN or logging in with 'gh auth login'): %s: %w", url, resp.Status, ErrAPIError)
-		}
-		if msg != "" {
-			return nil, fmt.Errorf("github api error for %s: %s: %s: %w", url, resp.Status, msg, ErrAPIError)
-		}
-		return nil, fmt.Errorf("github api error for %s: %s: %w", url, resp.Status, ErrAPIError)
+		return nil, apiErrorFromResponse(url, resp)
 	}
 
 	var r release

--- a/internal/tool/backend/github/backend_test.go
+++ b/internal/tool/backend/github/backend_test.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+func TestAPIErrorFromResponse(t *testing.T) {
+	t.Parallel()
+
+	const requestURL = "https://api.github.com/repos/o/r/releases"
+
+	t.Run("rate limit when body readable", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			Status:     "403 Forbidden",
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"API rate limit exceeded"}`)),
+		}
+		err := apiErrorFromResponse(requestURL, resp)
+		if !errors.Is(err, ErrAPIError) {
+			t.Fatalf("expected ErrAPIError, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "rate limit exceeded") {
+			t.Fatalf("expected rate-limit wording, got %v", err)
+		}
+	})
+
+	t.Run("includes body message", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			Status:     "404 Not Found",
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("Not Found")),
+		}
+		err := apiErrorFromResponse(requestURL, resp)
+		if !errors.Is(err, ErrAPIError) {
+			t.Fatalf("expected ErrAPIError, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "Not Found") {
+			t.Fatalf("expected body in error, got %v", err)
+		}
+	})
+
+	t.Run("status only when body empty", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			Status:     "500 Internal Server Error",
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+		err := apiErrorFromResponse(requestURL, resp)
+		if !errors.Is(err, ErrAPIError) {
+			t.Fatalf("expected ErrAPIError, got %v", err)
+		}
+		if strings.Contains(err.Error(), "reading body") {
+			t.Fatalf("unexpected read-body note: %v", err)
+		}
+	})
+
+	t.Run("read failure falls back to status and reports read error", func(t *testing.T) {
+		t.Parallel()
+		readErr := errors.New("boom")
+		resp := &http.Response{
+			Status:     "502 Bad Gateway",
+			StatusCode: http.StatusBadGateway,
+			Body:       io.NopCloser(errReader{err: readErr}),
+		}
+		err := apiErrorFromResponse(requestURL, resp)
+		if !errors.Is(err, ErrAPIError) {
+			t.Fatalf("expected ErrAPIError, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "502 Bad Gateway") {
+			t.Fatalf("expected status in error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "reading body") || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("expected read error detail, got %v", err)
+		}
+		// Must not claim rate limit when body was unreadable.
+		if strings.Contains(err.Error(), "rate limit exceeded for") {
+			t.Fatalf("rate-limit path must not trigger without body: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Problem
On non-OK GitHub API responses, `ListVersions` and `GetArtifacts` did `body, _ := io.ReadAll(resp.Body)`. A failed body read was silent, so rate-limit detection and error messages could degrade without any signal that the body never arrived.

## Change
- Add `apiErrorFromResponse` used by both call sites.
- On `ReadAll` failure: keep a status-level error, include the read error, still wrap `ErrAPIError`.
- When the body is readable: same rate-limit string detection and body-in-message behavior as before.
- Unit tests cover rate-limit, body message, empty body, and read failure.

## Verified
```
go test ./internal/tool/backend/github/... -count=1
```