### PR TITLE
🧹 Janitor: check UserHomeDir in OpenWebapp profile path

### DIFF
--- a/pkg/driver/opener/facade.go
+++ b/pkg/driver/opener/facade.go
@@ -2,6 +2,7 @@ package opener
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"workspaced/internal/configcue"
@@ -47,7 +48,10 @@ func OpenWebapp(ctx context.Context, wa WebappConfig) error {
 	}
 
 	if wa.Profile != "" {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
 		profileDir := filepath.Join(home, ".config/workspaced/webapp/profiles", wa.Profile)
 		args = append(args, "--user-data-dir="+profileDir)
 	}


### PR DESCRIPTION
## Summary

- When `wa.Profile != ""`, `OpenWebapp` used `home, _ := os.UserHomeDir()`.
- On failure, the profile path became relative under CWD (`.config/workspaced/webapp/profiles/...`), which can create profiles in unexpected places or fail obscurely.
- Check the error and return a wrapped failure before building `profileDir`, consistent with selfinstall/wallpaper/media call sites.

## Test plan

- [x] `go test ./pkg/driver/opener/...`
- [x] `go build ./pkg/driver/opener/...`
- [ ] Manual: OpenWebapp with a non-empty Profile still resolves under `$HOME/.config/workspaced/webapp/profiles/...`

Finding id: `opener-homedir`