### PR TITLE
🧹 Janitor: check UserHomeDir for local module ~ targetBase

### DIFF
--- a/internal/module/provider/local/provider.go
+++ b/internal/module/provider/local/provider.go
@@ -70,7 +70,10 @@ func (p *Provider) Resolve(ctx context.Context, req module.ResolveRequest) ([]mo
 			return nil, fmt.Errorf("%w: %q in module %q", ErrUnknownPreset, presetName, req.Ref)
 		}
 		if targetBase == "~" {
-			home, _ := os.UserHomeDir()
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get home directory: %w", err)
+			}
 			targetBase = home
 		}
 


### PR DESCRIPTION
## Problem

When resolving a local module with the `home` preset (`targetBase == "~"`), `os.UserHomeDir()` errors were ignored. That left `TargetBase` empty, so files deployed under CWD-relative paths instead of the user home.

## Change

Check the `UserHomeDir` error and return a wrapped failure, same pattern as the scanner plugin and opener facade.

## Verified

- `go build ./internal/module/provider/local/`
- `go test ./internal/module/...`