### PR TITLE
🧹 Janitor: handle error-body reads in llvm/grok-build tools

### DIFF
--- a/internal/tool/backend/catalog/applications/grok-build.go
+++ b/internal/tool/backend/catalog/applications/grok-build.go
@@ -149,8 +149,12 @@ func (t *grokBuildTool) probeLatest(ctx context.Context) (string, error) {
 			continue
 		}
 		if resp.StatusCode == http.StatusOK {
-			b, _ := io.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			logging.Close(ctx, resp.Body)
+			if err != nil {
+				// Read failure: treat as empty body and try the next channel.
+				continue
+			}
 			if s := strings.TrimSpace(string(b)); s != "" {
 				return s, nil
 			}

--- a/internal/tool/backend/catalog/applications/llvm.go
+++ b/internal/tool/backend/catalog/applications/llvm.go
@@ -60,12 +60,18 @@ func (t *llvmTool) ListVersions(ctx context.Context) ([]string, error) {
 	defer logging.Close(ctx, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("github releases for llvm: %s (reading body: %v)", resp.Status, err)
+		}
 		msg := strings.TrimSpace(string(body))
 		if resp.StatusCode == http.StatusForbidden && strings.Contains(msg, "rate limit") {
 			return nil, fmt.Errorf("github api rate limit exceeded for llvm releases (consider setting GITHUB_TOKEN or 'gh auth login')")
 		}
-		return nil, fmt.Errorf("github releases for llvm: %s: %s", resp.Status, msg)
+		if msg != "" {
+			return nil, fmt.Errorf("github releases for llvm: %s: %s", resp.Status, msg)
+		}
+		return nil, fmt.Errorf("github releases for llvm: %s", resp.Status)
 	}
 
 	var rels []struct {


### PR DESCRIPTION
## Problem
On non-OK HTTP responses, the llvm catalog tool discarded `io.ReadAll` errors when building the status message (`body, _ :=`). The grok-build probe did the same on the success-body path. Silent discard can hide real I/O failures; empty body as fallback is fine only when the code chooses that path explicitly.

Same pattern was fixed for the GitHub backend in #157.

## Change
- **llvm:** check `ReadAll` on error responses; include the read error in the status-only fallback; keep rate-limit wording detection when the body is readable; omit an empty body from the status error.
- **grok-build:** check `ReadAll` when probing stable channel version; on read failure, continue to the next channel (empty-body fallback).

## Verified
```bash
go test ./internal/tool/backend/catalog/... ./internal/tool/backend/github/...
```