### PR TITLE
🧹 Janitor: check UserHomeDir in history ingest

### DIFF
--- a/cmd/workspaced/utils/history/root.go
+++ b/cmd/workspaced/utils/history/root.go
@@ -29,7 +29,10 @@ func GetCommand() *cobra.Command {
 }
 
 func ingestBash(ctx context.Context) ([]types.HistoryEvent, error) {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
 	path := filepath.Join(home, ".bash_history")
 	file, err := os.Open(path)
 	if err != nil {
@@ -64,7 +67,10 @@ func ingestBash(ctx context.Context) ([]types.HistoryEvent, error) {
 }
 
 func ingestAtuin(ctx context.Context) ([]types.HistoryEvent, error) {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
 	dbPath := filepath.Join(home, ".local/share/atuin/history.db")
 
 	// Open atuin database using the registered sqlite driver


### PR DESCRIPTION
## Problem

`ingestBash` and `ingestAtuin` both did `home, _ := os.UserHomeDir()` then joined history paths. If home lookup failed, paths were wrong and callers only saw an obscure open/SQL error.

## Change

Check `UserHomeDir` errors and return `fmt.Errorf("failed to get home directory: %w", err)`, matching the rest of the tree (e.g. scanner / init).

## Verified

- `go build ./cmd/workspaced/utils/history/`