### PR TITLE
🧹 Janitor: check UserHomeDir for github input cache paths

### DIFF
--- a/internal/configcue/loader.go
+++ b/internal/configcue/loader.go
@@ -859,7 +859,10 @@ func resolveRuntimeInputs(configValue cue.Value, paths []string, discovered []La
 
 	modulesBaseDir := resolvedSelfModulesBase(paths, discovered)
 	workspaceRoot := filepath.Dir(modulesBaseDir)
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("user home dir: %w", err)
+	}
 	out := map[string]map[string]any{}
 	for name, input := range cfgInputs {
 		spec := strings.TrimSpace(input.From)

--- a/internal/configcue/loader_test.go
+++ b/internal/configcue/loader_test.go
@@ -32,8 +32,9 @@ func TestResolveRuntimeInputs_valid(t *testing.T) {
 	if got, ok := out["localmod"]["path"].(string); !ok || !strings.HasSuffix(filepath.Clean(got), filepath.Join("modules", "foo")) {
 		t.Fatalf("localmod path = %#v", out["localmod"])
 	}
-	if got, ok := out["gh"]["path"].(string); !ok || !strings.Contains(got, filepath.Join(".cache", "workspaced", "sources", "github")) {
-		t.Fatalf("gh path = %#v", out["gh"])
+	got, ok := out["gh"]["path"].(string)
+	if !ok || !filepath.IsAbs(got) || !strings.Contains(got, filepath.Join(".cache", "workspaced", "sources", "github")) {
+		t.Fatalf("gh path = %#v, want absolute cache path under .cache/workspaced/sources/github", out["gh"])
 	}
 }
 


### PR DESCRIPTION
## Problem

`resolveRuntimeInputs` ignored `os.UserHomeDir()` errors when building github input cache paths. On failure, `home` is empty and paths land under relative `.cache/workspaced/sources/github/...`, which is wrong and hard to debug.

Sibling call sites in the same file (`buildRuntimePrelude`, home-mode layer discovery) already check the error.

## Change

- Return `user home dir: %w` when `UserHomeDir` fails, same wording as `buildRuntimePrelude`.
- Tighten the existing github-path unit test so the resolved path must be absolute under `.cache/workspaced/sources/github`.

## Verified

```bash
go test ./internal/configcue/ -count=1
```