### PR TITLE
🧹 Janitor: log tray icon decode failures in daemon

### DIFF
--- a/cmd/workspaced/daemon/daemon.go
+++ b/cmd/workspaced/daemon/daemon.go
@@ -141,7 +141,10 @@ func RunDaemon(ctx context.Context) error {
 			f, err := os.Open(iconPath)
 			if err == nil {
 				defer logging.Close(ctx, f, "path", iconPath)
-				icon, _, _ = image.Decode(f)
+				icon, _, err = image.Decode(f)
+				if err != nil {
+					logger.Debug("failed to decode tray icon", "path", iconPath, "error", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

Tray setup does `icon, _, _ = image.Decode(f)`, so a corrupt or partial favicon PNG yields a nil icon with no log. Operators cannot tell why the tray has no icon.

## Change

Check the `image.Decode` error and log it at Debug (same level as a missing tray driver), leaving the icon nil so tray setup continues.

## Verified

- `go build ./cmd/workspaced/daemon/`