### PR TITLE
🧹 Janitor: check filepath.Rel in local module provider

### DIFF
--- a/internal/module/provider/local/provider.go
+++ b/internal/module/provider/local/provider.go
@@ -85,7 +85,10 @@ func (p *Provider) Resolve(ctx context.Context, req module.ResolveRequest) ([]mo
 			if info.IsDir() {
 				return nil
 			}
-			rel, _ := filepath.Rel(presetPath, path)
+			rel, err := filepath.Rel(presetPath, path)
+			if err != nil {
+				return err
+			}
 			isSymlink := info.Mode()&os.ModeSymlink != 0
 			out = append(out, module.ResolvedFile{
 				RelPath:    rel,


### PR DESCRIPTION
## Summary
- Surface `filepath.Rel` errors inside the local module provider Walk instead of discarding them with `_`.
- Avoid silent empty/wrong `RelPath` values when a path cannot be made relative to the preset base.

## Test plan
- [ ] `go build ./internal/module/provider/local/`
- [ ] Resolve a local module with home/etc-style presets and confirm RelPath values remain correct