### PR TITLE
🧹 Janitor: check UserHomeDir in home-apply GTK hook

### DIFF
--- a/cmd/workspaced/home/apply/root.go
+++ b/cmd/workspaced/home/apply/root.go
@@ -150,8 +150,13 @@ func Schedule(g *taskgroup.Group, cmd *cobra.Command, dryRun, showNoop bool) fun
 						return nil // Don't execute on phone
 					}
 
-					home, _ := os.UserHomeDir()
-					dummyTheme := home + "/.local/share/themes/dummy"
+					home, err := os.UserHomeDir()
+					if err != nil {
+						// Best-effort hook: skip GTK reload rather than fail apply.
+						logger.Warn("failed to get home directory for gtk theme reload", "error", err)
+						return nil
+					}
+					dummyTheme := filepath.Join(home, ".local", "share", "themes", "dummy")
 					if _, err := os.Stat(dummyTheme); err == nil {
 						targetTheme := "adw-gtk3-dark"
 						if readCmd, err := execdriver.Run(ctx, "dconf", "read", "/org/gnome/desktop/interface/gtk-theme"); err == nil {


### PR DESCRIPTION
## Summary
- The home-apply GTK theme reload `AfterFn` ignored `os.UserHomeDir()` errors (`home, _ := …`), so a failed home lookup produced an empty/wrong path for `Stat` on `…/.local/share/themes/dummy` and the hook silently no-oped (or hit a CWD-relative path).
- Check the error, log a `Warn`, and return `nil` so this best-effort hook does not fail apply.
- Build the dummy theme path with `filepath.Join`.

## Context
- Main apply path already checks `UserHomeDir` (lines 82–84).
- Taxonomy: ignored errors
- id: `home-apply-homedir`

## Test plan
- [ ] `go build ./cmd/workspaced/home/apply/...`
- [ ] Confirm apply still succeeds when home is available and GTK reload path is unchanged on success
- [ ] Mentally: if `UserHomeDir` fails, hook logs warn and skips without failing apply