### PR TITLE
🧹 Janitor: log renice failures in renice-hungry

### DIFF
--- a/cmd/workspaced/svc/renice_hungry.go
+++ b/cmd/workspaced/svc/renice_hungry.go
@@ -39,7 +39,10 @@ func init() {
 						}
 
 						logger.Info("renicing process", "pid", pid, "cmd", cmdline)
-						_ = execdriver.MustRun(ctx, "renice", "7", pid).Run()
+						if err := execdriver.MustRun(ctx, "renice", "7", pid).Run(); err != nil {
+							logger.Error("failed to renice process", "pid", pid, "cmd", cmdline, "error", err)
+							continue
+						}
 					}
 				}
 			},


### PR DESCRIPTION
## Summary
- Check `renice` `Run()` error in the renice-hungry service instead of discarding it.
- Log failures with `pid` / `cmd` / `error` and continue the loop so permission or missing-binary issues are visible.

## Why
`_ = execdriver.MustRun(...).Run()` swallowed permission/missing-renice failures while the Info log claimed renicing happened.

## Test plan
- [ ] `go build ./cmd/workspaced/...`
- [ ] Run `workspaced svc renice-hungry` without renice permissions and confirm Error logs include pid
- [ ] Confirm loop continues after failures