### PR TITLE
🧹 Janitor: check scanner errors in autoregistry ExtractPackage

### DIFF
--- a/internal/devtools/autoregistry/main.go
+++ b/internal/devtools/autoregistry/main.go
@@ -29,10 +29,17 @@ func ExtractPackage(ctx context.Context, gofile string) (string, error) {
 	}
 	defer logging.Close(ctx, f)
 	scanner := bufio.NewScanner(f)
-	scanner.Scan()
-	parts := strings.Split(scanner.Text(), " ")
-	return strings.TrimSpace(parts[1]), nil
-
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", fmt.Errorf("scan %s: %w", gofile, err)
+		}
+		return "", fmt.Errorf("no package line in %s", gofile)
+	}
+	parts := strings.Fields(scanner.Text())
+	if len(parts) < 2 || parts[0] != "package" {
+		return "", fmt.Errorf("no package line in %s", gofile)
+	}
+	return parts[1], nil
 }
 
 func (r DetectedRoot) Children(ctx context.Context) (iter.Seq[DetectedRoot], error) {


### PR DESCRIPTION
## Summary
- `ExtractPackage` ignored `scanner.Scan()`'s bool and never checked `scanner.Err()`.
- Empty or malformed files could panic on `parts[1]` or return a wrong package name.
- Now returns a clear error when scan fails, the file is empty, or the first line is not a valid `package` declaration.

## Test plan
- [ ] `go build ./internal/devtools/autoregistry/`
- [ ] Run autoregistry against a normal tree (existing package lines still parse)
- [ ] Empty / non-package first line returns a clear error instead of panic