### PR TITLE
🧹 Janitor: check rand.Read for remote nix build IDs

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -166,7 +166,9 @@ func RemoteBuild(ctx context.Context, ref string, target string, copyBack bool) 
 	}
 
 	buildID := make([]byte, 8)
-	_, _ = rand.Read(buildID)
+	if _, err := rand.Read(buildID); err != nil {
+		return "", fmt.Errorf("failed to generate build ID: %w", err)
+	}
 	uuid := fmt.Sprintf("%x", buildID)
 	outLink := fmt.Sprintf("%s/%s", remoteCache, uuid)
 


### PR DESCRIPTION
## Problem

`RemoteBuild` generates an 8-byte ID with `crypto/rand.Read` for the remote out-link path, but discards the error:

```go
buildID := make([]byte, 8)
_, _ = rand.Read(buildID)
```

On a rare Read failure the buffer stays zeroed, so the out-link becomes a fixed UUID and can collide under the remote cache.

## Change

Return a wrapped error when `rand.Read` fails, same pattern as `internal/sudo/sudo.go`.

## Verified

- `go build ./internal/nix/`