### PR TITLE
🧹 Janitor: fallback TaskName when icon Rel fails

### DIFF
--- a/internal/icons/theme_generate_engine.go
+++ b/internal/icons/theme_generate_engine.go
@@ -108,7 +108,12 @@ func runThemeGenerateEngine(ctx context.Context, opts ThemeGenerateOptions, inpu
 			// so that icons with the same basename in different categories
 			// (e.g. apps/brightnesssettings.svg vs devices/brightnesssettings.svg)
 			// get unique task names. This matches the deduplication key logic.
-			rel, _ := filepath.Rel(inputDir, iconPath)
+			// On Rel failure (e.g. paths on different volumes), fall back to the
+			// basename so progress labels stay unique-ish instead of collapsing.
+			rel, err := filepath.Rel(inputDir, iconPath)
+			if err != nil {
+				return "icon:" + filepath.Base(iconPath)
+			}
 			relOut := strings.TrimSuffix(rel, ".tmpl")
 			relOut = strings.TrimSuffix(relOut, ".svg") + ".svg"
 			relOut = stripLeadingSizeDir(relOut)


### PR DESCRIPTION
## Summary
- Check `filepath.Rel` in icon theme `taskgroup.Map` `TaskName` instead of discarding the error with `_`.
- On Rel failure, fall back to `filepath.Base(iconPath)` so progress UI labels stay unique-ish instead of collapsing.
- `Fn` still returns the Rel error unchanged; this only affects display names.

## Test plan
- [x] `go build ./internal/icons/`
- [ ] Generate an icon theme and confirm progress task names remain `icon:<rel-path>` for normal paths