### PR TITLE
🧹 Janitor: do not panic on ExtractPackage failure in autoregistry

### DIFF
--- a/internal/devtools/autoregistry/main.go
+++ b/internal/devtools/autoregistry/main.go
@@ -48,13 +48,15 @@ func (r DetectedRoot) Children(ctx context.Context) (iter.Seq[DetectedRoot], err
 		return nil, err
 	}
 	return func(yield func(DetectedRoot) bool) {
+		logger := logging.GetLogger(ctx)
 		for _, item := range items {
 			dirname := path.Base(path.Dir(item))
 			dir := path.Join(r.Dir, dirname)
 			file := path.Join(dir, "root.go")
 			pkg, err := ExtractPackage(ctx, file)
 			if err != nil {
-				panic(err)
+				logger.Warn("skipping root.go: ExtractPackage failed", "file", file, "error", err)
+				continue
 			}
 			if !yield(DetectedRoot{
 				Dir:        dir,


### PR DESCRIPTION
## Problem

`DetectedRoot.Children` called `panic(err)` when `ExtractPackage` failed. After the scanner fix, those errors are real (empty file, missing package line, IO), and a single bad `root.go` killed the entire autoregistry run.

## Change

On `ExtractPackage` failure, log a warning via `logging.GetLogger(ctx)` and skip that child. Other children still yield; codegen continues.

## Verified

- Diff is the panic → skip+log path only
- `gofmt` clean on the touched file