### PR TITLE
🧹 Janitor: log SetDPMS failures in screencaps

### DIFF
--- a/cmd/workspaced/svc/screencaps.go
+++ b/cmd/workspaced/svc/screencaps.go
@@ -57,7 +57,9 @@ func monitorCapsLock(ctx context.Context) {
 			}
 			if !capsActive != screenActive {
 				logger.Info("toggling screen", "active", !capsActive)
-				_ = screen.SetDPMS(ctx, !capsActive)
+				if err := screen.SetDPMS(ctx, !capsActive); err != nil {
+					logger.Error("failed to set screen DPMS", "active", !capsActive, "error", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Check `screen.SetDPMS` error in the screencaps service instead of discarding it with `_`.
- Log failures with desired DPMS active state so caps-lock screen control is no longer silent when DPMS toggle fails.

## Test plan
- [ ] `go build ./cmd/workspaced/svc/`
- [ ] Run `workspaced svc screencaps` and confirm a SetDPMS failure is logged with `active` and `error` fields