### PR TITLE
🧹 Janitor: check binary hash and marshal errors in utils client

### DIFF
--- a/cmd/workspaced/utils/root.go
+++ b/cmd/workspaced/utils/root.go
@@ -55,7 +55,12 @@ func TryRemoteRaw(ctx context.Context, cmdName string, args []string) (string, b
 	}
 	defer logging.Close(ctx, conn, "socket", socketPath)
 
-	clientHash, _ := executil.GetBinaryHash(ctx)
+	// Best-effort: daemon skips mismatch detection when BinaryHash is empty.
+	clientHash, err := executil.GetBinaryHash(ctx)
+	if err != nil {
+		logger.Warn("failed to hash client binary; daemon mismatch check skipped", "error", err)
+		clientHash = ""
+	}
 
 	req := types.Request{
 		Command:    cmdName,
@@ -64,7 +69,10 @@ func TryRemoteRaw(ctx context.Context, cmdName string, args []string) (string, b
 		BinaryHash: clientHash,
 	}
 
-	payload, _ := json.Marshal(req)
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to marshal daemon request: %w", err)
+	}
 	packet := types.StreamPacket{
 		Type:    "request",
 		Payload: payload,


### PR DESCRIPTION
## Problem

`TryRemoteRaw` dropped two errors on the daemon client path:

1. `clientHash, _ := executil.GetBinaryHash(ctx)` — hash failures became an empty `BinaryHash` with no log. The daemon only runs mismatch detection when `req.BinaryHash != ""` (`daemon.go`), so silent failures hide client/daemon drift.
2. `payload, _ := json.Marshal(req)` — marshal failures were ignored before `WriteJSON`.

## Change

- On `GetBinaryHash` failure: log a warn and send empty hash (same best-effort contract as the daemon when hash is missing or its own hash fails).
- On `json.Marshal` failure: return a wrapped error to the caller.

## Verified

- `go build ./cmd/workspaced/utils/`
- `go vet ./cmd/workspaced/utils/`