### PR TITLE
🧹 Janitor: log git rebase --abort failures

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -101,7 +101,9 @@ func SyncRepo(ctx context.Context, path string) error {
 
 	logger.Info("git pull --rebase", "path", path)
 	if err := execdriver.MustRun(ctx, "git", "-C", path, "pull", "--rebase").Run(); err != nil {
-		_ = execdriver.MustRun(ctx, "git", "-C", path, "rebase", "--abort").Run()
+		if abortErr := execdriver.MustRun(ctx, "git", "-C", path, "rebase", "--abort").Run(); abortErr != nil {
+			logging.ReportError(ctx, abortErr, "op", "git rebase --abort", "path", path)
+		}
 		return fmt.Errorf("git pull rebase failed (conflict?): %w", err)
 	}
 


### PR DESCRIPTION
## Problem

After `git pull --rebase` fails in `SyncRepo`, cleanup runs `git rebase --abort` but discards the error with `_ =`. Operators only see the pull/conflict error and may not notice the repo is still mid-rebase if abort also failed.

## Change

If `rebase --abort` fails, report it via `logging.ReportError` (with op/path). The returned error is still the pull rebase failure.

## Verified

- `go build ./internal/git/`