### PR TITLE
🧹 Janitor: use errors.Is for io.EOF in tar extractors

### DIFF
--- a/internal/modfile/sourceprovider/github/tarball.go
+++ b/internal/modfile/sourceprovider/github/tarball.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,7 +85,7 @@ func extractTarGz(ctx context.Context, r io.Reader, destDir string) error {
 	tr := tar.NewReader(gzr)
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {

--- a/internal/tool/backend/install/install.go
+++ b/internal/tool/backend/install/install.go
@@ -468,7 +468,7 @@ func untargz(ctx context.Context, src, dest string) error {
 func untar(ctx context.Context, reader *tar.Reader, dest string) error {
 	for {
 		header, err := reader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {


### PR DESCRIPTION
## Problem

Tar extract loops in install and the GitHub tarball provider compared `err == io.EOF`. That misses wrapped EOF and fails go errorlint / common Go practice for sentinel checks.

## Change

Use `errors.Is(err, io.EOF)` in both extract loops. Add the `errors` import on the tarball provider (install already had it).

## Verified

- `go test ./internal/tool/backend/install/ ./internal/modfile/sourceprovider/github/`