### PR TITLE
🧹 Janitor: check agent symlink error in grok-build install

### DIFF
--- a/internal/tool/backend/catalog/applications/grok-build.go
+++ b/internal/tool/backend/catalog/applications/grok-build.go
@@ -111,7 +111,9 @@ func (t *grokBuildTool) InstallArtifact(ctx context.Context, art backend.Artifac
 		agent = "agent.exe"
 	}
 	_ = os.Remove(filepath.Join(destDir, agent))
-	_ = os.Symlink(bin, filepath.Join(destDir, agent))
+	if err := os.Symlink(bin, filepath.Join(destDir, agent)); err != nil {
+		return fmt.Errorf("symlink agent: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- After the grok-build smoke test, install creates an `agent` / `agent.exe` symlink next to `grok`.
- Symlink errors were discarded with `_ = os.Symlink(...)`, so Install could return nil while the alias was missing.
- Still best-effort `os.Remove` of any existing agent path; on Symlink failure return `fmt.Errorf("symlink agent: %w", err)`.

## Test plan
- [x] `go build ./internal/tool/backend/catalog/applications/`
- [x] `go test ./internal/tool/backend/catalog/applications/ -count=1`