### PR TITLE
🧹 Janitor: log git rebase --abort failures in backup git sync

### DIFF
--- a/internal/backup/action_git_sync.go
+++ b/internal/backup/action_git_sync.go
@@ -12,6 +12,7 @@ import (
 
 	execdriver "workspaced/pkg/driver/exec"
 	"workspaced/pkg/driver/notification"
+	"workspaced/pkg/logging"
 )
 
 var (
@@ -211,7 +212,9 @@ func (a GitRepoSyncAction) remoteHasBranch(ctx context.Context, remoteName, bran
 
 func (a GitRepoSyncAction) pullRebase(ctx context.Context, remoteName, branch string) error {
 	if err := a.run(ctx, "pull", "--rebase", remoteName, branch); err != nil {
-		_ = a.run(ctx, "rebase", "--abort")
+		if abortErr := a.run(ctx, "rebase", "--abort"); abortErr != nil {
+			logging.ReportError(ctx, abortErr, "op", "git rebase --abort", "path", a.Src)
+		}
 		return fmt.Errorf("git pull --rebase failed for %s: %w", a.Src, err)
 	}
 	return nil


### PR DESCRIPTION
## Problem

In `GitRepoSyncAction.pullRebase`, a failed `git pull --rebase` always runs `git rebase --abort`, but the abort error was discarded with `_ = a.run(...)`. If abort also fails, the working tree can stay mid-rebase with no log line to explain it.

The same path in `internal/git/git.go` already reports abort failures via `logging.ReportError` (PR #174).

## Change

When `rebase --abort` fails, call `logging.ReportError` with `op`, `path` (src), and the abort error. Still return the original pull error as the primary result.

No contract change for successful sync; callers still only see the pull error. Abort failures become visible in logs only.

## How verified

- `gofmt` on the touched file
- `go test ./internal/backup/`