### PR TITLE
🧹 Janitor: handle filepath.Rel error in dotd concatenation

### DIFF
--- a/internal/source/plugin_dotd.go
+++ b/internal/source/plugin_dotd.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -62,7 +63,10 @@ func (p *DotDProcessorPlugin) Process(ctx context.Context, files []File) ([]File
 
 		// Use info from the first file for bases
 		first := groupFiles[0]
-		relPath, _ := filepath.Rel(first.TargetBase(), targetPath)
+		relPath, err := filepath.Rel(first.TargetBase(), targetPath)
+		if err != nil {
+			return nil, fmt.Errorf("dotd relative path for %q from %q: %w", targetPath, first.TargetBase(), err)
+		}
 
 		result = append(result, &ConcatenatedFile{
 			BasicFile: BasicFile{


### PR DESCRIPTION
## Summary
- Check `filepath.Rel` when building concatenated `.d` groups instead of discarding the error with `_`.
- On failure, return a wrapped error from `Process` so the apply path fails loud instead of writing concatenated content under a wrong/empty relative path.

## Test plan
- [x] `go build ./internal/source/`
- [ ] Apply a workspace with `.d.tmpl` groups and confirm normal concatenation still works