### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in modfile

### DIFF
--- a/internal/modfile/files.go
+++ b/internal/modfile/files.go
@@ -2,13 +2,14 @@ package modfile
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 )
 
 func EnsureLockFile(ctx context.Context, root string) (string, error) {
 	sumPath := filepath.Join(root, "workspaced.lock.json")
-	if _, err := os.Stat(sumPath); os.IsNotExist(err) {
+	if _, err := os.Stat(sumPath); errors.Is(err, os.ErrNotExist) {
 		if _, err := updateSumFile(ctx, sumPath, func(sum *SumFile) (bool, error) {
 			return len(sum.Dependencies) == 0, nil
 		}); err != nil {

--- a/internal/modfile/sumfile.go
+++ b/internal/modfile/sumfile.go
@@ -2,6 +2,7 @@ package modfile
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -119,7 +120,7 @@ type sumFileDisk struct {
 
 func LoadSumFile(path string) (*SumFile, error) {
 	out := &SumFile{}
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		return out, nil
 	}
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary
- Replace `os.IsNotExist(err)` with `errors.Is(err, os.ErrNotExist)` in `internal/modfile/files.go` and `sumfile.go` so wrapped not-exist errors are recognized (errorlint / Go best practice).
- Aligns with existing pattern in `internal/checks/detect.go`.

## Test plan
- [x] `go test ./internal/modfile/` (includes `TestEnsureLockFileCreatesLock`, `TestLoadSumFileMissingIsEmpty`)