### PR TITLE
🧹 Janitor: remove empty branch in tool lazy lock enrichment

### DIFF
--- a/internal/tool/lazy.go
+++ b/internal/tool/lazy.go
@@ -516,11 +516,5 @@ func lockedToolWithRenovate(lockRef string, version string, spec parsespec.Spec)
 	lt.PackageName = entry.PackageName
 	lt.Versioning = entry.Versioning
 
-	// The Tool had a chance to influence CurrentValue too.
-	if entry.CurrentValue != "" {
-		// We don't store CurrentValue on LockedTool (it lives on the dep),
-		// but the upsert logic will pick it up via other paths if needed.
-	}
-
 	return lt
 }


### PR DESCRIPTION
## Problem

`lockedToolWithRenovate` in `internal/tool/lazy.go` ended with an empty `if entry.CurrentValue != ""` after `EnrichLockfile`. staticcheck SA9003 flags empty branches; this one only held comments and did nothing.

## Change

Delete the no-op branch and its comments. `CurrentValue` is not copied onto `LockedTool` (it lives on the renovate dep via other paths), so the check never did work.

## Verified

- `go build ./internal/tool/`
- `go test ./internal/tool/ -count=1`