### PR TITLE
🧹 Janitor: rename sourceprovider common package to sourcecache

### DIFF
--- a/internal/modfile/sourceprovider/github/provider.go
+++ b/internal/modfile/sourceprovider/github/provider.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"workspaced/internal/modfile"
-	"workspaced/internal/modfile/sourceprovider/common"
+	"workspaced/internal/modfile/sourceprovider/sourcecache"
 	"workspaced/pkg/logging"
 )
 
@@ -132,7 +132,7 @@ func ensureGithubSource(ctx context.Context, alias string, src modfile.SourceCon
 
 	logger := logging.GetLogger(ctx)
 	logger.Info("resolving github source", "alias", s.Alias, "repo", s.Repo(), "ref", s.Ref(), "url", s.Config.URL)
-	return common.EnsureCachedDir(ctx, "github", s.CacheKey(), func(tmpDir string) error {
+	return sourcecache.EnsureCachedDir(ctx, "github", s.CacheKey(), func(tmpDir string) error {
 		meta, err := downloadAndExtractTarball(ctx, s, tmpDir, "")
 		if err != nil {
 			return fmt.Errorf("failed to fetch source %q: %w", alias, err)

--- a/internal/modfile/sourceprovider/sourcecache/cache.go
+++ b/internal/modfile/sourceprovider/sourcecache/cache.go
@@ -1,4 +1,4 @@
-package common
+package sourcecache
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- Rename `internal/modfile/sourceprovider/common` → `sourcecache` (package + directory)
- Update the sole importer (`github` provider) to use `sourcecache.EnsureCachedDir`
- Behavior identical; aligns with AGENTS.md ban on `utils`/`common` package names

## Test plan
- [x] `go test ./internal/modfile/sourceprovider/...`
- [x] `go build ./internal/modfile/sourceprovider/...`
- [x] `go build ./...`

Finding: rename-sourcecache