### PR TITLE
🧹 Janitor: drop failed-to prefix in git package errors

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -28,7 +28,7 @@ func QuickSync(ctx context.Context) error {
 	repoDir := quicksync.RepoDir
 	entries, err := os.ReadDir(repoDir)
 	if err != nil {
-		return fmt.Errorf("failed to read repo dir %s: %w", repoDir, err)
+		return fmt.Errorf("read repo dir %s: %w", repoDir, err)
 	}
 
 	var repos []string
@@ -124,7 +124,7 @@ func GetRoot(ctx context.Context, path string) (string, error) {
 	cmd := execdriver.MustRun(ctx, "git", "-C", path, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get git root: %w", err)
+		return "", fmt.Errorf("git root: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
## Problem
`QuickSync` / `GetRoot` wrap errors with `"failed to read repo dir"` / `"failed to get git root"`. Go style (Uber/Google) wants lowercase, succinct error strings without `"failed to"` padding that stacks as errors wrap.

## Change
Rewrite the two `fmt.Errorf` strings in `internal/git/git.go` only:
- `read repo dir %s: %w`
- `git root: %w`

Behavior unchanged; wrap targets are the same.

## Verified
- `go build ./internal/git/`
- `go test ./internal/git/` (no tests in package)
- No callers match the old string text