### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in plugin scanner

### DIFF
--- a/internal/source/plugin_scanner.go
+++ b/internal/source/plugin_scanner.go
@@ -53,7 +53,7 @@ func NewScannerPlugin(cfg ScannerConfig) (*ScannerPlugin, error) {
 		baseDir = filepath.Join(home, baseDir[2:])
 	}
 
-	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
+	if _, err := os.Stat(baseDir); errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("%w: %s", ErrBaseDirNotExist, baseDir)
 	}
 


### PR DESCRIPTION
## Problem
`NewScannerPlugin` checks missing base dirs with `os.IsNotExist`. That only matches the bare sentinel and misses wrapped errors (Go best practice: use `errors.Is`).

## Change
- `internal/source/plugin_scanner.go`: `os.IsNotExist(err)` → `errors.Is(err, os.ErrNotExist)`

No behavior change for plain `os.Stat` failures; wrapped `ErrNotExist` is now detected correctly.

## Verified
- `go test ./internal/source/ -count=1`