### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in template dotd

### DIFF
--- a/internal/template/dotd.go
+++ b/internal/template/dotd.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 
 // ProcessDotD processes a .d.tmpl directory (file concatenation).
 func (e *Engine) ProcessDotD(ctx context.Context, dirPath string, data any) ([]byte, error) {
-	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+	if _, err := os.Stat(dirPath); errors.Is(err, os.ErrNotExist) {
 		return nil, nil // Empty content if directory doesn't exist
 	}
 


### PR DESCRIPTION
## Summary
- Replace `os.IsNotExist(err)` with `errors.Is(err, os.ErrNotExist)` in `internal/template/dotd.go` so wrapped not-exist errors are recognized (errorlint / Go best practice).
- Aligns with `internal/checks/detect.go` and the recent modfile janitor fix.

## Test plan
- [x] `go test ./internal/template/` (no test files; package builds clean)
- [x] `go build ./internal/template/`