### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in deployer state

### DIFF
--- a/internal/deployer/state.go
+++ b/internal/deployer/state.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,7 +50,7 @@ func (s *FileStateStore) Load() (*State, error) {
 	state := &State{Files: make(map[string]ManagedInfo)}
 
 	// If the file does not exist, return an empty state
-	if _, err := os.Stat(s.path); os.IsNotExist(err) {
+	if _, err := os.Stat(s.path); errors.Is(err, os.ErrNotExist) {
 		return state, nil
 	}
 


### PR DESCRIPTION
## Problem

`FileStateStore.Load` used `os.IsNotExist(err)`, which does not unwrap wrapped errors. Go style (and the rest of this tree after recent janitor work) prefers `errors.Is(err, os.ErrNotExist)`.

## Change

In `internal/deployer/state.go`, check missing state files with `errors.Is(err, os.ErrNotExist)`. Behavior is unchanged for plain `fs.ErrNotExist` from `os.Stat`; wrapped not-exist errors now also yield an empty state instead of falling through to `ReadFile`.

## Verified

- `go test ./internal/deployer/...`