### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in cas

### DIFF
--- a/internal/cas/cas.go
+++ b/internal/cas/cas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -58,7 +59,7 @@ func (c *CASWriter) Seal() (string, error) {
 	hashStr := hex.EncodeToString(hash)
 	finalPath := filepath.Join(c.dir, hashStr)
 
-	if _, err := os.Stat(finalPath); os.IsNotExist(err) {
+	if _, err := os.Stat(finalPath); errors.Is(err, os.ErrNotExist) {
 		if err := os.Rename(c.tempFile.Name(), finalPath); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Problem

`Seal` checks absence with `os.IsNotExist(err)`. That helper does not unwrap, so wrapped not-exist errors slip past. Go style (and errorlint) prefers `errors.Is(err, os.ErrNotExist)`.

## Change

In `internal/cas/cas.go`, replace `os.IsNotExist(err)` with `errors.Is(err, os.ErrNotExist)` and import `errors`. Behavior is otherwise the same.

## Verify

- `go build ./internal/cas/...`