### PR TITLE
🧹 Janitor: drop failed-to prefix in screenshot driver errors

### DIFF
--- a/pkg/driver/screenshot/facade.go
+++ b/pkg/driver/screenshot/facade.go
@@ -65,7 +65,7 @@ func Capture(ctx context.Context, targetType TargetType) (string, error) {
 
 	dir := screenshot.Dir
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create screenshot dir: %w", err)
+		return "", fmt.Errorf("create screenshot dir: %w", err)
 	}
 
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
@@ -74,12 +74,12 @@ func Capture(ctx context.Context, targetType TargetType) (string, error) {
 
 	f, err := os.Create(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to create screenshot file: %w", err)
+		return "", fmt.Errorf("create screenshot file: %w", err)
 	}
 	defer logging.Close(ctx, f)
 
 	if err := png.Encode(f, img); err != nil {
-		return "", fmt.Errorf("failed to encode screenshot: %w", err)
+		return "", fmt.Errorf("encode screenshot: %w", err)
 	}
 
 	// Post-processing: Clipboard

--- a/pkg/driver/screenshot/grim/driver.go
+++ b/pkg/driver/screenshot/grim/driver.go
@@ -82,7 +82,7 @@ func (d *Driver) Capture(ctx context.Context, rect *api.Rect) (image.Image, erro
 
 	img, _, err := image.Decode(bytes.NewReader(out))
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode grim output: %w", err)
+		return nil, fmt.Errorf("decode grim output: %w", err)
 	}
 
 	return img, nil

--- a/pkg/driver/screenshot/maim/driver.go
+++ b/pkg/driver/screenshot/maim/driver.go
@@ -78,7 +78,7 @@ func (d *Driver) Capture(ctx context.Context, rect *api.Rect) (image.Image, erro
 
 	img, _, err := image.Decode(bytes.NewReader(out))
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode maim output: %w", err)
+		return nil, fmt.Errorf("decode maim output: %w", err)
 	}
 
 	return img, nil


### PR DESCRIPTION
## Problem

Screenshot driver error strings used a `failed to …` prefix. That padding stacks when errors wrap and fights Go's usual style (short, lowercase context).

## Change

Drop the prefix in facade create/encode paths and grim/maim decode paths, matching the same cleanup already landed for executil/git.

| Location | Before | After |
|----------|--------|-------|
| `facade.go` | `failed to create screenshot dir` | `create screenshot dir` |
| `facade.go` | `failed to create screenshot file` | `create screenshot file` |
| `facade.go` | `failed to encode screenshot` | `encode screenshot` |
| `grim/driver.go` | `failed to decode grim output` | `decode grim output` |
| `maim/driver.go` | `failed to decode maim output` | `decode maim output` |

No behavior change — message text only.

## Verified

- Diff limited to the five `fmt.Errorf` call sites above
- Strings stay lowercase and wrap-friendly with `%w`