### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in tool checks

### DIFF
--- a/internal/tool/checks/checks.go
+++ b/internal/tool/checks/checks.go
@@ -125,7 +125,7 @@ func (c pathCheck) Check(ctx context.Context, destDir string) error {
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("%s: %w", path, fs.ErrNotExist)
 		}
 		return err


### PR DESCRIPTION
## Problem

`pathCheck.Check` used `os.IsNotExist`, which does not unwrap errors. That misses wrapped not-exist results and trips `errorlint`.

## Change

Use `errors.Is(err, os.ErrNotExist)` in `internal/tool/checks/checks.go`, same pattern as cas, modfile, deployer, and template/dotd.

## Verify

```bash
go test ./internal/tool/checks/ -count=1
```