### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in tool manager

### DIFF
--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -2,6 +2,7 @@ package tool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -194,7 +195,7 @@ func (m *Manager) ListInstalled() ([]InstalledTool, error) {
 	var tools []InstalledTool
 
 	entries, err := os.ReadDir(m.toolsDir)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
## Problem

`ListInstalled` used `os.IsNotExist(err)` after `os.ReadDir`. That helper does not unwrap, so wrapped not-exist errors are missed, and errorlint flags the call site.

## Change

Replace with `errors.Is(err, os.ErrNotExist)` and add the `errors` import. Same pattern as cas/modfile/scanner migrations.

## Verified

```
go test ./internal/tool/ -count=1
```