### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in place module

### DIFF
--- a/internal/module/provider/core/place.go
+++ b/internal/module/provider/core/place.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -81,7 +82,7 @@ func (placeModule) Resolve(ctx context.Context, req module.ResolveRequest) ([]mo
 
 		st, err := os.Stat(srcPath)
 		if err != nil {
-			if cfg.IgnoreMissing && os.IsNotExist(err) {
+			if cfg.IgnoreMissing && errors.Is(err, os.ErrNotExist) {
 				logger.Info("place: skipping missing source", "module", req.ModuleName, "dest", dest, "source", srcPath)
 				continue
 			}


### PR DESCRIPTION
## Problem

`os.IsNotExist` does not unwrap errors. After `os.Stat` in `core:place`, a wrapped not-exist result is missed when `ignore_missing` is set, and errorlint flags the call.

## Change

In `internal/module/provider/core/place.go`, replace `os.IsNotExist(err)` with `errors.Is(err, os.ErrNotExist)` and add the `errors` import.

## Verified

```bash
go test ./internal/module/provider/core/ -count=1
```