### PR TITLE
🧹 Janitor: drop failed-to prefix in template package errors

### DIFF
--- a/internal/template/dotd.go
+++ b/internal/template/dotd.go
@@ -33,13 +33,13 @@ func (e *Engine) ProcessDotD(ctx context.Context, dirPath string, data any) ([]b
 		filePath := filepath.Join(dirPath, fileName)
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read %s: %w", fileName, err)
+			return nil, fmt.Errorf("read %s: %w", fileName, err)
 		}
 
 		if strings.HasSuffix(fileName, ".tmpl") {
 			rendered, err := e.Render(ctx, string(content), data)
 			if err != nil {
-				return nil, fmt.Errorf("failed to render template %s: %w", fileName, err)
+				return nil, fmt.Errorf("render template %s: %w", fileName, err)
 			}
 			result.Write(rendered)
 		} else {

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -52,7 +52,7 @@ func WithFuncMap(funcMap template.FuncMap) Option {
 func (e *Engine) Render(ctx context.Context, tmpl string, data any) ([]byte, error) {
 	t, err := template.New("template").Funcs(e.funcMap).Parse(tmpl)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse template: %w", err)
+		return nil, fmt.Errorf("parse template: %w", err)
 	}
 
 	var buf bytes.Buffer
@@ -60,7 +60,7 @@ func (e *Engine) Render(ctx context.Context, tmpl string, data any) ([]byte, err
 		if errors.Is(err, ErrFileSkipped) {
 			return nil, ErrFileSkipped
 		}
-		return nil, fmt.Errorf("failed to execute template: %w", err)
+		return nil, fmt.Errorf("execute template: %w", err)
 	}
 
 	return buf.Bytes(), nil
@@ -70,7 +70,7 @@ func (e *Engine) Render(ctx context.Context, tmpl string, data any) ([]byte, err
 func (e *Engine) RenderFile(ctx context.Context, path string, data any) ([]byte, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read template file: %w", err)
+		return nil, fmt.Errorf("read template file: %w", err)
 	}
 
 	return e.Render(ctx, string(content), data)


### PR DESCRIPTION
## Problem

`internal/template` wraps errors with a `failed to …` prefix. That stacks when callers wrap again and fights Go style (short, lowercase context). Same cleanup already landed for git/screenshot/executil.

## Change

Drop the `failed to ` prefix in `fmt.Errorf` strings only:

- `parse template` / `execute template` / `read template file` (`engine.go`)
- `read %s` / `render template %s` (`dotd.go`)

`%w` wrapping and arguments are unchanged. Message-only; no behavior change.

## Verify

```
go test ./internal/template/ -count=1
```

(no test files in package; compile/check only)