### PR TITLE
🧹 Janitor: drop failed-to prefix in palette package errors

### DIFF
--- a/pkg/palette/palette.go
+++ b/pkg/palette/palette.go
@@ -41,13 +41,13 @@ func DriverNames() []string {
 func ExtractFromFile(ctx context.Context, path string, driver string, opts api.Options) (*api.Palette, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open image: %w", err)
+		return nil, fmt.Errorf("open image: %w", err)
 	}
 	defer logging.Close(ctx, f)
 
 	img, _, err := image.Decode(f)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode image: %w", err)
+		return nil, fmt.Errorf("decode image: %w", err)
 	}
 
 	d, err := GetDriver(ctx, driver)


### PR DESCRIPTION
## Problem

`ExtractFromFile` wraps open/decode failures with `"failed to open/decode image"`. Go style wants lowercase, succinct error strings without `"failed to"` padding that stacks as errors wrap.

## Change

Message-only edit of two `fmt.Errorf` strings in `pkg/palette/palette.go`:
- `open image: %w`
- `decode image: %w`

`%w` wrapping and behavior are unchanged.

## Verified

- `go test ./pkg/palette/ -count=1`