### PR TITLE
🧹 Janitor: use errors.Is for os.ErrNotExist in actionlint check

### DIFF
--- a/internal/checks/lint/actionlint/actionlint.go
+++ b/internal/checks/lint/actionlint/actionlint.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func (c *check) Detect(ctx context.Context, dir string) error {
 	// Applies if .github/workflows exists and is not empty
 	workflowsDir := filepath.Join(dir, ".github", "workflows")
 	entries, err := os.ReadDir(workflowsDir)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return checks.ErrNotApplicable
 	}
 	if err != nil {


### PR DESCRIPTION
## Problem

`Detect` used `os.IsNotExist(err)` after `os.ReadDir`. That helper does not unwrap errors, so wrapped not-exist results are missed. errorlint also prefers `errors.Is`.

## Change

Replace with `errors.Is(err, os.ErrNotExist)` and import `errors`. Same pattern as other janitor isnotexist fixes in this tree.

## Verified

```
go test ./internal/checks/lint/actionlint/ -count=1
```

Package has no test files; compile succeeds.