### PR TITLE
feat(codebase): experimental LSP router proxy

### DIFF
--- a/cmd/workspaced/codebase/lsp.go
+++ b/cmd/workspaced/codebase/lsp.go
@@ -1,0 +1,61 @@
+package codebase
+
+import (
+	"fmt"
+	"os"
+
+	"workspaced/internal/lsp"
+	"workspaced/pkg/logging"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	Registry.Register(func(c *cobra.Command) {
+		c.AddCommand(&cobra.Command{
+			Use:   "lsp",
+			Short: "Language server router (stdio LSP proxy driven by workspaced.cue)",
+			Long: `Speak LSP on stdio and route to language servers declared in codebase workspaced.cue.
+
+The editor should use this as its only language server. On initialize, the
+client root is taken from rootUri (single workspace folder only). Config is
+loaded from that root's workspaced.cue lsp block:
+
+  workspaced: {
+    lsp: {
+      extensions: { ".go": "go" }
+      language_ids: { go: "go", gomod: "go" }
+      languages: {
+        go: {
+          "00_gopls": { capabilities: { hover: true, definition: true, completion: true, diagnostics: true } }
+        }
+      }
+      servers: {
+        gopls: {
+          cmd: ["gopls"]
+          needs: { gopls: true } // optional lazy_tools names to ensure first
+        }
+      }
+    }
+    lazy_tools: {
+      gopls: { ref: "..." }
+    }
+  }
+
+An empty or missing lsp block still accepts the connection; document methods
+return unsupported until routes exist.
+
+Stdout is the LSP wire. Logs go to stderr.`,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				ctx := cmd.Context()
+				logger := logging.GetLogger(ctx)
+				logger.Info("codebase lsp starting (stdio)")
+				err := lsp.Run(ctx, os.Stdin, os.Stdout)
+				if err != nil {
+					return fmt.Errorf("lsp: %w", err)
+				}
+				return nil
+			},
+		})
+	})
+}

--- a/cmd/workspaced/codebase/lsp.go
+++ b/cmd/workspaced/codebase/lsp.go
@@ -14,8 +14,10 @@ func init() {
 	Registry.Register(func(c *cobra.Command) {
 		c.AddCommand(&cobra.Command{
 			Use:   "lsp",
-			Short: "Language server router (stdio LSP proxy driven by workspaced.cue)",
-			Long: `Speak LSP on stdio and route to language servers declared in codebase workspaced.cue.
+			Short: "Experimental: language server router (stdio LSP proxy driven by workspaced.cue)",
+			Long: `Experimental. Speak LSP on stdio and route to language servers declared in codebase workspaced.cue.
+
+API, cue schema, and merge behavior may change without a migration path.
 
 The editor should use this as its only language server. On initialize, the
 client root is taken from rootUri (single workspace folder only). Config is

--- a/internal/configcue/schema.cue
+++ b/internal/configcue/schema.cue
@@ -127,4 +127,39 @@ workspaced: {
 	lazy_tools?: [string]: #LazyTool
 	drivers?: [string]: [string]: int
 	concurrency?: #Concurrency
+
+	// LSP router: language servers behind `workspaced codebase lsp`.
+	// Empty / omitted means the proxy still speaks LSP but routes nowhere.
+	lsp?: #LSP
+}
+
+// #LSP is the codebase-local language server router config.
+#LSP: {
+	// extension (with or without leading dot) -> our language id
+	extensions?: [string]: string
+	// editor languageId -> our language id (used when extension map misses)
+	language_ids?: [string]: string
+	// our language -> ordered server attachments (keys like "00_gopls")
+	languages?: [string]: #LSPLanguage
+	// server id -> process definition
+	servers?: [string]: #LSPServer
+	// soft timeout per backend request (Go duration string), default applied in code
+	request_timeout?: string
+}
+
+#LSPLanguage: {
+	// ordered attachment key -> capabilities this server may handle for the language
+	[string]: #LSPAttachment
+}
+
+#LSPAttachment: {
+	// capability flags (hover, definition, diagnostics, …). Empty = all.
+	capabilities?: [string]: bool
+}
+
+#LSPServer: {
+	// argv for the language server (stdio)
+	cmd: [...string] & [_, ...]
+	// lazy_tools names to ensure before spawn (map for deep-merge)
+	needs?: [string]: bool
 }

--- a/internal/lsp/backend.go
+++ b/internal/lsp/backend.go
@@ -1,0 +1,258 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"workspaced/internal/tool"
+	execdriver "workspaced/pkg/driver/exec"
+	"workspaced/pkg/logging"
+)
+
+// Backend is one running language server process.
+type Backend struct {
+	ID       string
+	ServerID string
+	conn     *Conn
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+
+	nextID atomic.Int64
+
+	mu      sync.Mutex
+	pending map[string]chan *Message // id string -> response
+
+	onNotification func(serverID string, msg *Message)
+
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+}
+
+// StartBackend ensures tools, spawns the server, and runs a read loop.
+func StartBackend(ctx context.Context, root string, serverID string, srv Server, onNotification func(serverID string, msg *Message)) (*Backend, error) {
+	logger := logging.GetLogger(ctx)
+	if len(srv.Cmd) == 0 {
+		return nil, fmt.Errorf("server %q: empty cmd", serverID)
+	}
+
+	argv, envExtra, err := resolveServerCmd(ctx, root, srv)
+	if err != nil {
+		return nil, fmt.Errorf("server %q: %w", serverID, err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	cmd, err := execdriver.Run(runCtx, argv[0], argv[1:]...)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("server %q: exec: %w", serverID, err)
+	}
+	cmd.Dir = root
+	if len(envExtra) > 0 {
+		cmd.Env = append(os.Environ(), envExtra...)
+	}
+	// Language servers log to stderr; keep visible on our stderr.
+	cmd.Stderr = os.Stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		_ = stdin.Close()
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("server %q: start: %w", serverID, err)
+	}
+	logger.Info("lsp backend started", "server", serverID, "cmd", argv, "pid", cmd.Process.Pid)
+
+	b := &Backend{
+		ID:             serverID,
+		ServerID:       serverID,
+		conn:           NewConn(stdout, stdin),
+		cmd:            cmd,
+		cancel:         cancel,
+		pending:        map[string]chan *Message{},
+		onNotification: onNotification,
+		stdin:          stdin,
+		stdout:         stdout,
+	}
+	go b.readLoop(ctx)
+	go func() {
+		err := cmd.Wait()
+		logger.Info("lsp backend exited", "server", serverID, "error", err)
+		b.failPending(fmt.Errorf("server %q exited: %w", serverID, err))
+	}()
+	return b, nil
+}
+
+func resolveServerCmd(ctx context.Context, root string, srv Server) (argv []string, envExtra []string, err error) {
+	argv = append([]string(nil), srv.Cmd...)
+	var pathDirs []string
+
+	for name, on := range srv.Needs {
+		if !on {
+			continue
+		}
+		// Prefer resolving the binary named like cmd[0] when it matches; else first bin via empty.
+		binName := filepath.Base(argv[0])
+		binPath, rerr := tool.ResolveLazyToolAt(ctx, root, name, binName)
+		if rerr != nil {
+			// Try resolving with the lazy tool name as bin hint.
+			binPath, rerr = tool.ResolveLazyToolAt(ctx, root, name, name)
+		}
+		if rerr != nil {
+			return nil, nil, fmt.Errorf("ensure lazy tool %q: %w", name, rerr)
+		}
+		dir := filepath.Dir(binPath)
+		pathDirs = append(pathDirs, dir)
+		// Expand cmd[0] when it matches this binary name.
+		if filepath.Base(argv[0]) == filepath.Base(binPath) || argv[0] == name {
+			argv[0] = binPath
+		}
+	}
+
+	if len(pathDirs) > 0 {
+		path := strings.Join(pathDirs, string(os.PathListSeparator))
+		if existing := os.Getenv("PATH"); existing != "" {
+			path = path + string(os.PathListSeparator) + existing
+		}
+		envExtra = append(envExtra, "PATH="+path)
+	}
+
+	// If still not absolute, try which with augmented path in process env for which only.
+	if !filepath.IsAbs(argv[0]) {
+		// which uses process PATH; temporarily not ideal — leave bare and rely on PATH env for the child.
+	}
+	return argv, envExtra, nil
+}
+
+func (b *Backend) readLoop(ctx context.Context) {
+	logger := logging.GetLogger(ctx)
+	for {
+		msg, err := b.conn.ReadMessage()
+		if err != nil {
+			if err != io.EOF && !strings.Contains(err.Error(), "file already closed") {
+				logger.Debug("backend read ended", "server", b.ServerID, "error", err)
+			}
+			b.failPending(err)
+			return
+		}
+		if msg.IsResponse() {
+			id := string(msg.ID)
+			b.mu.Lock()
+			ch, ok := b.pending[id]
+			if ok {
+				delete(b.pending, id)
+			}
+			b.mu.Unlock()
+			if ok {
+				ch <- msg
+			}
+			continue
+		}
+		// Notifications and server->client requests: forward upward.
+		if b.onNotification != nil {
+			b.onNotification(b.ServerID, msg)
+		}
+	}
+}
+
+func (b *Backend) failPending(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for id, ch := range b.pending {
+		ch <- &Message{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage(id),
+			Error:   &RespError{Code: CodeInternalError, Message: err.Error()},
+		}
+		delete(b.pending, id)
+	}
+}
+
+// Notify sends a notification (no response).
+func (b *Backend) Notify(method string, params any) error {
+	var raw json.RawMessage
+	if params != nil {
+		body, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		raw = body
+	}
+	return b.conn.WriteMessage(&Message{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  raw,
+	})
+}
+
+// Request sends a request and waits for the response (caller applies timeout via ctx).
+func (b *Backend) Request(ctx context.Context, method string, params any) (*Message, error) {
+	idNum := b.nextID.Add(1)
+	idRaw, _ := json.Marshal(idNum)
+
+	var raw json.RawMessage
+	if params != nil {
+		body, err := json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+		raw = body
+	}
+
+	ch := make(chan *Message, 1)
+	idKey := string(idRaw)
+	b.mu.Lock()
+	b.pending[idKey] = ch
+	b.mu.Unlock()
+
+	if err := b.conn.WriteMessage(&Message{
+		JSONRPC: "2.0",
+		ID:      idRaw,
+		Method:  method,
+		Params:  raw,
+	}); err != nil {
+		b.mu.Lock()
+		delete(b.pending, idKey)
+		b.mu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case <-ctx.Done():
+		b.mu.Lock()
+		delete(b.pending, idKey)
+		b.mu.Unlock()
+		return nil, ctx.Err()
+	case msg := <-ch:
+		return msg, nil
+	}
+}
+
+// Close stops the backend process.
+func (b *Backend) Close() {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	if b.stdin != nil {
+		_ = b.stdin.Close()
+	}
+	if b.cmd != nil && b.cmd.Process != nil {
+		_ = b.cmd.Process.Kill()
+	}
+}

--- a/internal/lsp/capabilities.go
+++ b/internal/lsp/capabilities.go
@@ -1,0 +1,69 @@
+package lsp
+
+import "encoding/json"
+
+// advertisedCapabilities is the full proxy surface ("announce all").
+// Methods without a live backend return MethodNotFound / null as appropriate.
+func advertisedCapabilities() json.RawMessage {
+	// Full textDocumentSync (simplest reliable route for multi-backend replay).
+	const caps = `{
+		"textDocumentSync": {
+			"openClose": true,
+			"change": 1,
+			"save": { "includeText": true }
+		},
+		"hoverProvider": true,
+		"completionProvider": {
+			"triggerCharacters": [".", ":", "/", "\"", "'"],
+			"resolveProvider": true
+		},
+		"signatureHelpProvider": {
+			"triggerCharacters": ["(", ","]
+		},
+		"definitionProvider": true,
+		"typeDefinitionProvider": true,
+		"implementationProvider": true,
+		"referencesProvider": true,
+		"documentHighlightProvider": true,
+		"documentSymbolProvider": true,
+		"workspaceSymbolProvider": true,
+		"codeActionProvider": true,
+		"codeLensProvider": { "resolveProvider": true },
+		"documentFormattingProvider": true,
+		"documentRangeFormattingProvider": true,
+		"renameProvider": { "prepareProvider": true },
+		"documentLinkProvider": { "resolveProvider": true },
+		"foldingRangeProvider": true,
+		"selectionRangeProvider": true,
+		"inlayHintProvider": true,
+		"diagnosticProvider": {
+			"interFileDependencies": true,
+			"workspaceDiagnostics": false
+		},
+		"semanticTokensProvider": {
+			"legend": {
+				"tokenTypes": ["namespace","type","class","enum","interface","struct","typeParameter","parameter","variable","property","enumMember","event","function","method","macro","keyword","modifier","comment","string","number","regexp","operator"],
+				"tokenModifiers": ["declaration","definition","readonly","static","deprecated","abstract","async","modification","documentation","defaultLibrary"]
+			},
+			"full": true,
+			"range": true
+		},
+		"workspace": {
+			"workspaceFolders": {
+				"supported": false
+			}
+		}
+	}`
+	return json.RawMessage(caps)
+}
+
+// initializeResult builds the initialize response.
+func initializeResult(rootURI string) map[string]any {
+	return map[string]any{
+		"capabilities": advertisedCapabilities(),
+		"serverInfo": map[string]any{
+			"name":    "workspaced",
+			"version": "lsp-router",
+		},
+	}
+}

--- a/internal/lsp/config.go
+++ b/internal/lsp/config.go
@@ -1,0 +1,253 @@
+// Package lsp implements the workspaced language-server router proxy.
+package lsp
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"workspaced/internal/configcue"
+)
+
+const defaultRequestTimeout = 10 * time.Second
+
+// Config is the decoded workspaced.lsp block.
+type Config struct {
+	Extensions     map[string]string              `json:"extensions"`
+	LanguageIDs    map[string]string              `json:"language_ids"`
+	Languages      map[string]map[string]Attachment `json:"languages"`
+	Servers        map[string]Server              `json:"servers"`
+	RequestTimeout string                         `json:"request_timeout"`
+}
+
+// Attachment binds an ordered language entry to capability flags.
+type Attachment struct {
+	Capabilities map[string]bool `json:"capabilities"`
+}
+
+// Server is a language-server process definition.
+type Server struct {
+	Cmd   []string        `json:"cmd"`
+	Needs map[string]bool `json:"needs"`
+}
+
+// LanguageBinding is one ordered server attachment after resolving order keys.
+type LanguageBinding struct {
+	OrderKey     string
+	ServerID     string
+	Capabilities map[string]bool // nil/empty = all
+}
+
+var orderPrefix = regexp.MustCompile(`^(\d+_)?(.*)$`)
+
+// LoadConfig decodes workspaced.lsp from a loaded config. Missing block yields empty Config.
+func LoadConfig(cfg *configcue.Config) (Config, error) {
+	if cfg == nil {
+		return Config{}, nil
+	}
+	var out Config
+	if err := cfg.Decode("lsp", &out); err != nil {
+		if errors.Is(err, configcue.ErrKeyNotFound) {
+			return Config{}, nil
+		}
+		return Config{}, fmt.Errorf("decode lsp config: %w", err)
+	}
+	normalizeConfig(&out)
+	return out, nil
+}
+
+func normalizeConfig(c *Config) {
+	if c.Extensions == nil {
+		c.Extensions = map[string]string{}
+	}
+	if c.LanguageIDs == nil {
+		c.LanguageIDs = map[string]string{}
+	}
+	// Normalize extension keys to include a leading dot and lowercase.
+	normExt := make(map[string]string, len(c.Extensions))
+	for k, v := range c.Extensions {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		if !strings.HasPrefix(k, ".") {
+			k = "." + k
+		}
+		normExt[strings.ToLower(k)] = strings.TrimSpace(v)
+	}
+	c.Extensions = normExt
+
+	normIDs := make(map[string]string, len(c.LanguageIDs))
+	for k, v := range c.LanguageIDs {
+		normIDs[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	c.LanguageIDs = normIDs
+}
+
+// Timeout returns the per-backend request soft timeout.
+func (c Config) Timeout() time.Duration {
+	if strings.TrimSpace(c.RequestTimeout) == "" {
+		return defaultRequestTimeout
+	}
+	d, err := time.ParseDuration(c.RequestTimeout)
+	if err != nil || d <= 0 {
+		return defaultRequestTimeout
+	}
+	return d
+}
+
+// ResolveLanguage maps path + editor languageId to our language id.
+// Extension map wins; language_ids is fallback.
+func (c Config) ResolveLanguage(pathOrURI, languageID string) string {
+	path := uriToPath(pathOrURI)
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != "" {
+		if lang, ok := c.Extensions[ext]; ok && lang != "" {
+			return lang
+		}
+	}
+	// basename match for extensionless files (e.g. Dockerfile) — key ".dockerfile" style not used;
+	// allow keys that are the full base name stored as ".Dockerfile" unlikely; skip.
+	if languageID != "" {
+		if lang, ok := c.LanguageIDs[languageID]; ok && lang != "" {
+			return lang
+		}
+	}
+	return ""
+}
+
+// BindingsFor returns ordered server bindings for a language.
+func (c Config) BindingsFor(language string) []LanguageBinding {
+	raw, ok := c.Languages[language]
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(raw))
+	for k := range raw {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]LanguageBinding, 0, len(keys))
+	for _, k := range keys {
+		att := raw[k]
+		serverID := serverIDFromOrderKey(k)
+		if serverID == "" {
+			continue
+		}
+		if _, ok := c.Servers[serverID]; !ok {
+			// Still emit binding; spawn will fail with a clear error.
+		}
+		caps := att.Capabilities
+		out = append(out, LanguageBinding{
+			OrderKey:     k,
+			ServerID:     serverID,
+			Capabilities: caps,
+		})
+	}
+	return out
+}
+
+func serverIDFromOrderKey(key string) string {
+	m := orderPrefix.FindStringSubmatch(key)
+	if len(m) == 3 && m[2] != "" {
+		return m[2]
+	}
+	return key
+}
+
+// HasCapability reports whether the binding handles cap.
+// Empty capabilities map means all.
+func (b LanguageBinding) HasCapability(cap string) bool {
+	if len(b.Capabilities) == 0 {
+		return true
+	}
+	// Allow either exact or true-valued entries; missing = false when map non-empty.
+	v, ok := b.Capabilities[cap]
+	return ok && v
+}
+
+// CapabilityForMethod maps an LSP method to a capability flag name.
+func CapabilityForMethod(method string) string {
+	switch method {
+	case "textDocument/hover":
+		return "hover"
+	case "textDocument/definition":
+		return "definition"
+	case "textDocument/typeDefinition":
+		return "typeDefinition"
+	case "textDocument/implementation":
+		return "implementation"
+	case "textDocument/references":
+		return "references"
+	case "textDocument/completion":
+		return "completion"
+	case "textDocument/signatureHelp":
+		return "signatureHelp"
+	case "textDocument/documentHighlight":
+		return "documentHighlight"
+	case "textDocument/documentSymbol":
+		return "documentSymbol"
+	case "textDocument/codeAction":
+		return "codeAction"
+	case "textDocument/codeLens":
+		return "codeLens"
+	case "textDocument/formatting":
+		return "formatting"
+	case "textDocument/rangeFormatting":
+		return "rangeFormatting"
+	case "textDocument/rename":
+		return "rename"
+	case "textDocument/prepareRename":
+		return "prepareRename"
+	case "textDocument/inlayHint":
+		return "inlayHint"
+	case "textDocument/semanticTokens/full", "textDocument/semanticTokens/range":
+		return "semanticTokens"
+	case "textDocument/documentLink":
+		return "documentLink"
+	case "textDocument/foldingRange":
+		return "foldingRange"
+	case "textDocument/selectionRange":
+		return "selectionRange"
+	case "workspace/symbol":
+		return "workspaceSymbol"
+	case "textDocument/diagnostic", "textDocument/publishDiagnostics":
+		return "diagnostics"
+	default:
+		// Unknown methods: treat capability name as last path segment.
+		if i := strings.LastIndex(method, "/"); i >= 0 {
+			return method[i+1:]
+		}
+		return method
+	}
+}
+
+func uriToPath(uri string) string {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return ""
+	}
+	const prefix = "file://"
+	if strings.HasPrefix(uri, prefix) {
+		p := strings.TrimPrefix(uri, prefix)
+		// file:///path -> /path; Windows file:///C:/... left as-is for now
+		if strings.HasPrefix(p, "/") && len(p) >= 3 && p[2] == ':' {
+			// file:///C:/...
+			return p[1:]
+		}
+		return p
+	}
+	return uri
+}
+
+func pathToURI(path string) string {
+	path = filepath.ToSlash(path)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return "file://" + path
+}

--- a/internal/lsp/config_test.go
+++ b/internal/lsp/config_test.go
@@ -1,0 +1,92 @@
+package lsp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveLanguageExtensionFirst(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		Extensions:  map[string]string{".go": "go"},
+		LanguageIDs: map[string]string{"python": "python", "go": "go_from_id"},
+	}
+	normalizeConfig(&cfg)
+
+	if got := cfg.ResolveLanguage("file:///x/y/z.go", "python"); got != "go" {
+		t.Fatalf("extension should win: got %q", got)
+	}
+	if got := cfg.ResolveLanguage("file:///x/y/z.py", "python"); got != "python" {
+		t.Fatalf("language id fallback: got %q", got)
+	}
+	if got := cfg.ResolveLanguage("file:///x/y/z.rs", "rust"); got != "" {
+		t.Fatalf("unmapped: got %q", got)
+	}
+}
+
+func TestBindingsForOrderAndServerID(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		Languages: map[string]map[string]Attachment{
+			"go": {
+				"99_refactree": {Capabilities: map[string]bool{"references": true}},
+				"00_gopls":     {Capabilities: map[string]bool{"hover": true}},
+			},
+		},
+		Servers: map[string]Server{
+			"gopls":     {Cmd: []string{"gopls"}},
+			"refactree": {Cmd: []string{"refactree"}},
+		},
+	}
+	b := cfg.BindingsFor("go")
+	if len(b) != 2 {
+		t.Fatalf("len=%d", len(b))
+	}
+	if b[0].ServerID != "gopls" || b[0].OrderKey != "00_gopls" {
+		t.Fatalf("first=%+v", b[0])
+	}
+	if b[1].ServerID != "refactree" {
+		t.Fatalf("second=%+v", b[1])
+	}
+	if !b[0].HasCapability("hover") || b[0].HasCapability("references") {
+		t.Fatalf("gopls caps")
+	}
+	// empty caps = all
+	all := LanguageBinding{ServerID: "x"}
+	if !all.HasCapability("anything") {
+		t.Fatal("empty caps should allow all")
+	}
+}
+
+func TestTimeoutDefault(t *testing.T) {
+	t.Parallel()
+	if (Config{}).Timeout() != defaultRequestTimeout {
+		t.Fatal("default")
+	}
+	if (Config{RequestTimeout: "2s"}).Timeout() != 2*time.Second {
+		t.Fatal("parsed")
+	}
+	if (Config{RequestTimeout: "nope"}).Timeout() != defaultRequestTimeout {
+		t.Fatal("bad parse fallback")
+	}
+}
+
+func TestCapabilityForMethod(t *testing.T) {
+	t.Parallel()
+	if CapabilityForMethod("textDocument/hover") != "hover" {
+		t.Fatal()
+	}
+	if CapabilityForMethod("workspace/symbol") != "workspaceSymbol" {
+		t.Fatal()
+	}
+}
+
+func TestServerIDFromOrderKey(t *testing.T) {
+	t.Parallel()
+	if serverIDFromOrderKey("00_gopls") != "gopls" {
+		t.Fatal()
+	}
+	if serverIDFromOrderKey("gopls") != "gopls" {
+		t.Fatal()
+	}
+}

--- a/internal/lsp/docs.go
+++ b/internal/lsp/docs.go
@@ -1,0 +1,76 @@
+package lsp
+
+import "sync"
+
+// Document is a cached text document.
+type Document struct {
+	URI        string
+	LanguageID string
+	Language   string // our resolved language
+	Version    int
+	Text       string
+}
+
+// DocStore holds open documents.
+type DocStore struct {
+	mu   sync.RWMutex
+	docs map[string]*Document
+}
+
+// NewDocStore creates an empty store.
+func NewDocStore() *DocStore {
+	return &DocStore{docs: map[string]*Document{}}
+}
+
+// Put inserts or replaces a document.
+func (s *DocStore) Put(doc *Document) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *doc
+	s.docs[doc.URI] = &cp
+}
+
+// Get returns a copy of the document if present.
+func (s *DocStore) Get(uri string) (*Document, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.docs[uri]
+	if !ok {
+		return nil, false
+	}
+	cp := *d
+	return &cp, true
+}
+
+// Delete removes a document.
+func (s *DocStore) Delete(uri string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.docs, uri)
+}
+
+// All returns copies of every open document.
+func (s *DocStore) All() []*Document {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*Document, 0, len(s.docs))
+	for _, d := range s.docs {
+		cp := *d
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// ByLanguage returns documents for a language.
+func (s *DocStore) ByLanguage(lang string) []*Document {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []*Document
+	for _, d := range s.docs {
+		if d.Language == lang {
+			cp := *d
+			out = append(out, &cp)
+		}
+	}
+	return out
+}

--- a/internal/lsp/jsonrpc.go
+++ b/internal/lsp/jsonrpc.go
@@ -1,0 +1,164 @@
+package lsp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Message is a JSON-RPC 2.0 message (request, response, or notification).
+type Message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RespError      `json:"error,omitempty"`
+}
+
+// RespError is a JSON-RPC error object.
+type RespError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// Error codes (JSON-RPC + LSP).
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+	CodeRequestFailed  = -32803 // LSP
+)
+
+// IsRequest reports whether the message expects a response.
+func (m *Message) IsRequest() bool {
+	return m.Method != "" && len(m.ID) > 0 && string(m.ID) != "null"
+}
+
+// IsNotification reports a method call with no id.
+func (m *Message) IsNotification() bool {
+	return m.Method != "" && (len(m.ID) == 0 || string(m.ID) == "null")
+}
+
+// IsResponse reports a result/error reply.
+func (m *Message) IsResponse() bool {
+	return m.Method == "" && len(m.ID) > 0
+}
+
+// Conn is a Content-Length framed JSON-RPC stream pair.
+type Conn struct {
+	in  *bufio.Reader
+	out io.Writer
+	mu  sync.Mutex // serializes writes
+}
+
+// NewConn wraps reader/writer for LSP framing.
+func NewConn(r io.Reader, w io.Writer) *Conn {
+	return &Conn{in: bufio.NewReader(r), out: w}
+}
+
+// ReadMessage reads one framed message.
+func (c *Conn) ReadMessage() (*Message, error) {
+	contentLen := -1
+	for {
+		line, err := c.in.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		const prefix = "Content-Length:"
+		if strings.HasPrefix(strings.ToLower(line), strings.ToLower(prefix)) {
+			v := strings.TrimSpace(line[len(prefix):])
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("content-length: %w", err)
+			}
+			contentLen = n
+		}
+	}
+	if contentLen < 0 {
+		return nil, fmt.Errorf("missing Content-Length")
+	}
+	body := make([]byte, contentLen)
+	if _, err := io.ReadFull(c.in, body); err != nil {
+		return nil, err
+	}
+	var msg Message
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return nil, fmt.Errorf("decode jsonrpc: %w", err)
+	}
+	if msg.JSONRPC == "" {
+		msg.JSONRPC = "2.0"
+	}
+	return &msg, nil
+}
+
+// WriteMessage writes one framed message.
+func (c *Conn) WriteMessage(msg *Message) error {
+	if msg.JSONRPC == "" {
+		msg.JSONRPC = "2.0"
+	}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var hdr bytes.Buffer
+	fmt.Fprintf(&hdr, "Content-Length: %d\r\n\r\n", len(body))
+	if _, err := c.out.Write(hdr.Bytes()); err != nil {
+		return err
+	}
+	_, err = c.out.Write(body)
+	return err
+}
+
+// WriteError responds to a request with an error.
+func (c *Conn) WriteError(id json.RawMessage, code int, message string) error {
+	return c.WriteMessage(&Message{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &RespError{Code: code, Message: message},
+	})
+}
+
+// WriteResult responds to a request with a result payload.
+func (c *Conn) WriteResult(id json.RawMessage, result any) error {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return c.WriteMessage(&Message{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  raw,
+	})
+}
+
+// WriteNotification sends a method with params and no id.
+func (c *Conn) WriteNotification(method string, params any) error {
+	var raw json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		raw = b
+	}
+	return c.WriteMessage(&Message{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  raw,
+	})
+}

--- a/internal/lsp/jsonrpc_test.go
+++ b/internal/lsp/jsonrpc_test.go
@@ -1,0 +1,66 @@
+package lsp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConnRoundTrip(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	c := NewConn(strings.NewReader(""), &buf)
+	msg := &Message{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"rootUri":"file:///tmp"}`),
+	}
+	if err := c.WriteMessage(msg); err != nil {
+		t.Fatal(err)
+	}
+	raw := buf.String()
+	if !strings.Contains(raw, "Content-Length:") {
+		t.Fatalf("header missing: %q", raw)
+	}
+	rc := NewConn(strings.NewReader(raw), &buf)
+	got, err := rc.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != "initialize" {
+		t.Fatalf("method=%s", got.Method)
+	}
+	if !got.IsRequest() {
+		t.Fatal("expected request")
+	}
+}
+
+func TestMergeResultsArrays(t *testing.T) {
+	t.Parallel()
+	out := mergeResults([]json.RawMessage{
+		json.RawMessage(`[{"uri":"a"}]`),
+		json.RawMessage(`[{"uri":"b"}]`),
+		json.RawMessage(`null`),
+	})
+	var items []map[string]string
+	if err := json.Unmarshal(out, &items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len=%d %s", len(items), out)
+	}
+}
+
+func TestMergeResultsFirstNonNull(t *testing.T) {
+	t.Parallel()
+	out := mergeResults([]json.RawMessage{
+		json.RawMessage(`null`),
+		json.RawMessage(`{"contents":"hi"}`),
+		json.RawMessage(`{"contents":"other"}`),
+	})
+	if string(out) != `{"contents":"hi"}` {
+		t.Fatalf("got %s", out)
+	}
+}

--- a/internal/lsp/merge.go
+++ b/internal/lsp/merge.go
@@ -1,0 +1,108 @@
+package lsp
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// mergeResults combines backend results. Array results are concatenated;
+// otherwise the first non-null result in order wins.
+func mergeResults(results []json.RawMessage) json.RawMessage {
+	if len(results) == 0 {
+		return json.RawMessage("null")
+	}
+
+	var arrays []json.RawMessage
+	allArray := true
+	for _, r := range results {
+		if len(r) == 0 || string(r) == "null" {
+			continue
+		}
+		trim := bytes.TrimSpace(r)
+		if len(trim) == 0 || trim[0] != '[' {
+			allArray = false
+			break
+		}
+		arrays = append(arrays, r)
+	}
+	if allArray && len(arrays) > 0 {
+		return concatJSONArrays(arrays)
+	}
+
+	// CompletionList-like: { isIncomplete, items: [] }
+	if merged, ok := mergeCompletionLists(results); ok {
+		return merged
+	}
+
+	for _, r := range results {
+		if len(r) == 0 || string(r) == "null" {
+			continue
+		}
+		return r
+	}
+	return json.RawMessage("null")
+}
+
+func concatJSONArrays(arrays []json.RawMessage) json.RawMessage {
+	var out []json.RawMessage
+	for _, a := range arrays {
+		var items []json.RawMessage
+		if err := json.Unmarshal(a, &items); err != nil {
+			continue
+		}
+		out = append(out, items...)
+	}
+	if out == nil {
+		return json.RawMessage("[]")
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return json.RawMessage("[]")
+	}
+	return b
+}
+
+func mergeCompletionLists(results []json.RawMessage) (json.RawMessage, bool) {
+	type cl struct {
+		IsIncomplete bool              `json:"isIncomplete"`
+		Items        []json.RawMessage `json:"items"`
+	}
+	var lists []cl
+	for _, r := range results {
+		if len(r) == 0 || string(r) == "null" {
+			continue
+		}
+		trim := bytes.TrimSpace(r)
+		if len(trim) == 0 || trim[0] != '{' {
+			return nil, false
+		}
+		var c cl
+		if err := json.Unmarshal(r, &c); err != nil {
+			return nil, false
+		}
+		// Heuristic: must have items key semantics
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(r, &probe); err != nil {
+			return nil, false
+		}
+		if _, ok := probe["items"]; !ok {
+			return nil, false
+		}
+		lists = append(lists, c)
+	}
+	if len(lists) == 0 {
+		return nil, false
+	}
+	var merged cl
+	for _, l := range lists {
+		if l.IsIncomplete {
+			merged.IsIncomplete = true
+		}
+		merged.Items = append(merged.Items, l.Items...)
+	}
+	b, err := json.Marshal(merged)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}

--- a/internal/lsp/proxy.go
+++ b/internal/lsp/proxy.go
@@ -1,0 +1,651 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"workspaced/internal/configcue"
+	"workspaced/pkg/logging"
+)
+
+// Proxy is the editor-facing LSP router.
+type Proxy struct {
+	client  *Conn
+	cfg     Config
+	root    string
+	rootURI string
+	docs    *DocStore
+	ctx     context.Context // root ctx for backend goroutines / logging
+
+	mu       sync.Mutex
+	backends map[string]*Backend // serverID -> backend
+	// language -> serverIDs started for it (for sync fan-out)
+	langServers map[string][]LanguageBinding
+	initParams  json.RawMessage // client initialize params for backend init
+
+	timeout time.Duration
+}
+
+// Run starts the proxy on the given client streams until exit/shutdown.
+func Run(ctx context.Context, r io.Reader, w io.Writer) error {
+	p := &Proxy{
+		client:      NewConn(r, w),
+		docs:        NewDocStore(),
+		backends:    map[string]*Backend{},
+		langServers: map[string][]LanguageBinding{},
+		timeout:     defaultRequestTimeout,
+		ctx:         ctx,
+	}
+	return p.loop(ctx)
+}
+
+func (p *Proxy) loop(ctx context.Context) error {
+	logger := logging.GetLogger(ctx)
+	for {
+		msg, err := p.client.ReadMessage()
+		if err != nil {
+			if err == io.EOF {
+				p.closeAll()
+				return nil
+			}
+			return err
+		}
+		if err := p.handleClient(ctx, msg); err != nil {
+			if err == io.EOF {
+				p.closeAll()
+				return nil
+			}
+			logger.Error("lsp handle client", "method", msg.Method, "error", err)
+			if msg.IsRequest() {
+				_ = p.client.WriteError(msg.ID, CodeInternalError, err.Error())
+			}
+		}
+	}
+}
+
+func (p *Proxy) handleClient(ctx context.Context, msg *Message) error {
+	switch {
+	case msg.IsRequest():
+		return p.handleRequest(ctx, msg)
+	case msg.IsNotification():
+		return p.handleNotification(ctx, msg)
+	default:
+		return nil
+	}
+}
+
+func (p *Proxy) handleRequest(ctx context.Context, msg *Message) error {
+	switch msg.Method {
+	case "initialize":
+		return p.onInitialize(ctx, msg)
+	case "shutdown":
+		p.closeAll()
+		return p.client.WriteResult(msg.ID, nil)
+	case "exit":
+		p.closeAll()
+		return io.EOF
+	default:
+		return p.forwardRequest(ctx, msg)
+	}
+}
+
+func (p *Proxy) handleNotification(ctx context.Context, msg *Message) error {
+	switch msg.Method {
+	case "initialized":
+		return nil
+	case "exit":
+		p.closeAll()
+		return io.EOF
+	case "textDocument/didOpen":
+		return p.onDidOpen(ctx, msg)
+	case "textDocument/didChange":
+		return p.onDidChange(ctx, msg)
+	case "textDocument/didClose":
+		return p.onDidClose(ctx, msg)
+	case "textDocument/didSave":
+		return p.fanoutNotify(ctx, msg, true)
+	case "$/cancelRequest":
+		// Best-effort ignore for v1.
+		return nil
+	default:
+		// Workspace or other notifications: fan-out to all live backends.
+		return p.fanoutNotifyAll(ctx, msg)
+	}
+}
+
+func (p *Proxy) onInitialize(ctx context.Context, msg *Message) error {
+	logger := logging.GetLogger(ctx)
+
+	var params struct {
+		RootURI               string `json:"rootUri"`
+		RootPath              string `json:"rootPath"`
+		WorkspaceFolders      []struct {
+			URI  string `json:"uri"`
+			Name string `json:"name"`
+		} `json:"workspaceFolders"`
+		Capabilities json.RawMessage `json:"capabilities"`
+	}
+	if len(msg.Params) > 0 {
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return p.client.WriteError(msg.ID, CodeInvalidParams, err.Error())
+		}
+	}
+
+	if len(params.WorkspaceFolders) > 1 {
+		return p.client.WriteError(msg.ID, CodeInvalidParams, "workspaced lsp requires a single workspace folder")
+	}
+
+	rootURI := params.RootURI
+	if rootURI == "" && len(params.WorkspaceFolders) == 1 {
+		rootURI = params.WorkspaceFolders[0].URI
+	}
+	if rootURI == "" && params.RootPath != "" {
+		rootURI = pathToURI(params.RootPath)
+	}
+	if rootURI == "" {
+		return p.client.WriteError(msg.ID, CodeInvalidParams, "missing rootUri")
+	}
+
+	root, err := filepath.Abs(uriToPath(rootURI))
+	if err != nil {
+		return p.client.WriteError(msg.ID, CodeInvalidParams, err.Error())
+	}
+
+	// Load codebase config at client root (empty lsp block is fine).
+	cueCfg, err := configcue.LoadForWorkspace(ctx, root)
+	if err != nil {
+		logger.Warn("lsp: load codebase config failed; continuing with empty lsp routes", "root", root, "error", err)
+		p.cfg = Config{}
+	} else {
+		cfg, err := LoadConfig(cueCfg)
+		if err != nil {
+			return p.client.WriteError(msg.ID, CodeInternalError, err.Error())
+		}
+		p.cfg = cfg
+	}
+	p.timeout = p.cfg.Timeout()
+	p.root = root
+	p.rootURI = rootURI
+	p.initParams = msg.Params
+
+	logger.Info("lsp initialized", "root", root, "servers", len(p.cfg.Servers), "languages", len(p.cfg.Languages))
+	return p.client.WriteResult(msg.ID, initializeResult(rootURI))
+}
+
+func (p *Proxy) onDidOpen(ctx context.Context, msg *Message) error {
+	var params struct {
+		TextDocument struct {
+			URI        string `json:"uri"`
+			LanguageID string `json:"languageId"`
+			Version    int    `json:"version"`
+			Text       string `json:"text"`
+		} `json:"textDocument"`
+	}
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return err
+	}
+	td := params.TextDocument
+	lang := p.cfg.ResolveLanguage(td.URI, td.LanguageID)
+	p.docs.Put(&Document{
+		URI:        td.URI,
+		LanguageID: td.LanguageID,
+		Language:   lang,
+		Version:    td.Version,
+		Text:       td.Text,
+	})
+	if lang == "" {
+		return nil
+	}
+	if err := p.ensureLanguage(ctx, lang); err != nil {
+		logging.GetLogger(ctx).Warn("lsp ensure language", "language", lang, "error", err)
+		return nil
+	}
+	// Async full sync fan-out.
+	go p.syncNotify(ctx, lang, "textDocument/didOpen", msg.Params)
+	return nil
+}
+
+func (p *Proxy) onDidChange(ctx context.Context, msg *Message) error {
+	var params struct {
+		TextDocument struct {
+			URI     string `json:"uri"`
+			Version int    `json:"version"`
+		} `json:"textDocument"`
+		ContentChanges []struct {
+			Text string `json:"text"`
+		} `json:"contentChanges"`
+	}
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return err
+	}
+	doc, ok := p.docs.Get(params.TextDocument.URI)
+	if !ok {
+		return nil
+	}
+	// Full sync from client (we advertise change=1 Full). Last change text is whole buffer.
+	if n := len(params.ContentChanges); n > 0 {
+		doc.Text = params.ContentChanges[n-1].Text
+	}
+	doc.Version = params.TextDocument.Version
+	p.docs.Put(doc)
+	if doc.Language == "" {
+		return nil
+	}
+	// Rebuild full-sync notify for backends (always full text).
+	fullParams := map[string]any{
+		"textDocument": map[string]any{
+			"uri":     doc.URI,
+			"version": doc.Version,
+		},
+		"contentChanges": []map[string]any{
+			{"text": doc.Text},
+		},
+	}
+	raw, _ := json.Marshal(fullParams)
+	go p.syncNotify(ctx, doc.Language, "textDocument/didChange", raw)
+	return nil
+}
+
+func (p *Proxy) onDidClose(ctx context.Context, msg *Message) error {
+	var params struct {
+		TextDocument struct {
+			URI string `json:"uri"`
+		} `json:"textDocument"`
+	}
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return err
+	}
+	doc, ok := p.docs.Get(params.TextDocument.URI)
+	lang := ""
+	if ok {
+		lang = doc.Language
+	}
+	p.docs.Delete(params.TextDocument.URI)
+	if lang != "" {
+		go p.syncNotify(ctx, lang, "textDocument/didClose", msg.Params)
+	}
+	return nil
+}
+
+func (p *Proxy) syncNotify(ctx context.Context, lang, method string, params json.RawMessage) {
+	bindings := p.bindingsLive(lang)
+	var wg sync.WaitGroup
+	for _, b := range bindings {
+		backend := p.getBackend(b.ServerID)
+		if backend == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(backend *Backend) {
+			defer wg.Done()
+			var raw any
+			_ = json.Unmarshal(params, &raw)
+			if err := backend.Notify(method, raw); err != nil {
+				logging.GetLogger(ctx).Debug("lsp sync notify", "server", backend.ServerID, "method", method, "error", err)
+			}
+		}(backend)
+	}
+	wg.Wait()
+}
+
+func (p *Proxy) fanoutNotify(ctx context.Context, msg *Message, requireDoc bool) error {
+	uri := extractURI(msg.Params)
+	lang := ""
+	if uri != "" {
+		if doc, ok := p.docs.Get(uri); ok {
+			lang = doc.Language
+		} else if requireDoc {
+			lang = p.cfg.ResolveLanguage(uri, "")
+		}
+	}
+	if lang == "" {
+		return p.fanoutNotifyAll(ctx, msg)
+	}
+	go p.syncNotify(ctx, lang, msg.Method, msg.Params)
+	return nil
+}
+
+func (p *Proxy) fanoutNotifyAll(ctx context.Context, msg *Message) error {
+	p.mu.Lock()
+	backends := make([]*Backend, 0, len(p.backends))
+	for _, b := range p.backends {
+		backends = append(backends, b)
+	}
+	p.mu.Unlock()
+	var raw any
+	_ = json.Unmarshal(msg.Params, &raw)
+	for _, b := range backends {
+		backend := b
+		go func() {
+			if err := backend.Notify(msg.Method, raw); err != nil {
+				logging.GetLogger(ctx).Debug("lsp notify all", "server", backend.ServerID, "error", err)
+			}
+		}()
+	}
+	return nil
+}
+
+func (p *Proxy) forwardRequest(ctx context.Context, msg *Message) error {
+	cap := CapabilityForMethod(msg.Method)
+	uri := extractURI(msg.Params)
+	lang := ""
+	if uri != "" {
+		if doc, ok := p.docs.Get(uri); ok {
+			lang = doc.Language
+		} else {
+			lang = p.cfg.ResolveLanguage(uri, "")
+		}
+	}
+
+	// Workspace-scoped methods without a document: all languages' servers that claim the cap.
+	var targets []*Backend
+	if lang != "" {
+		if err := p.ensureLanguage(ctx, lang); err != nil {
+			logging.GetLogger(ctx).Warn("lsp ensure language", "language", lang, "error", err)
+		}
+		for _, b := range p.bindingsLive(lang) {
+			if !b.HasCapability(cap) {
+				continue
+			}
+			if backend := p.getBackend(b.ServerID); backend != nil {
+				targets = append(targets, backend)
+			}
+		}
+	} else {
+		// Try every live backend whose any binding has the cap — for workspace/* etc.
+		p.mu.Lock()
+		for _, backend := range p.backends {
+			targets = append(targets, backend)
+		}
+		p.mu.Unlock()
+		// Filter by capability using any language binding that uses this server.
+		filtered := targets[:0]
+		for _, backend := range targets {
+			if p.serverHasCapability(backend.ServerID, cap) {
+				filtered = append(filtered, backend)
+			}
+		}
+		targets = filtered
+	}
+
+	if len(targets) == 0 {
+		return p.client.WriteError(msg.ID, CodeMethodNotFound, fmt.Sprintf("unsupported: %s", msg.Method))
+	}
+
+	var rawParams any
+	if len(msg.Params) > 0 {
+		_ = json.Unmarshal(msg.Params, &rawParams)
+	}
+
+	type one struct {
+		msg *Message
+		err error
+	}
+	results := make([]one, len(targets))
+	var wg sync.WaitGroup
+	for i, backend := range targets {
+		wg.Add(1)
+		go func(i int, backend *Backend) {
+			defer wg.Done()
+			reqCtx, cancel := context.WithTimeout(ctx, p.timeout)
+			defer cancel()
+			resp, err := backend.Request(reqCtx, msg.Method, rawParams)
+			results[i] = one{msg: resp, err: err}
+		}(i, backend)
+	}
+	wg.Wait()
+
+	var merged []json.RawMessage
+	var lastErr error
+	for _, r := range results {
+		if r.err != nil {
+			lastErr = r.err
+			continue // soft timeout / failure: exclude from this merge
+		}
+		if r.msg == nil {
+			continue
+		}
+		if r.msg.Error != nil {
+			lastErr = fmt.Errorf("%s", r.msg.Error.Message)
+			continue
+		}
+		if len(r.msg.Result) > 0 {
+			merged = append(merged, r.msg.Result)
+		}
+	}
+	if len(merged) == 0 {
+		if lastErr != nil {
+			return p.client.WriteError(msg.ID, CodeRequestFailed, lastErr.Error())
+		}
+		return p.client.WriteError(msg.ID, CodeMethodNotFound, fmt.Sprintf("unsupported: %s", msg.Method))
+	}
+
+	out := mergeResults(merged)
+	return p.client.WriteMessage(&Message{
+		JSONRPC: "2.0",
+		ID:      msg.ID,
+		Result:  out,
+	})
+}
+
+func (p *Proxy) serverHasCapability(serverID, cap string) bool {
+	for _, bindings := range p.langServers {
+		for _, b := range bindings {
+			if b.ServerID == serverID && b.HasCapability(cap) {
+				return true
+			}
+		}
+	}
+	// If we don't track bindings yet, allow.
+	return len(p.langServers) == 0
+}
+
+func (p *Proxy) ensureLanguage(ctx context.Context, lang string) error {
+	p.mu.Lock()
+	if _, ok := p.langServers[lang]; ok {
+		p.mu.Unlock()
+		return nil
+	}
+	// Mark in-progress so concurrent callers wait on the same start.
+	p.langServers[lang] = nil
+	p.mu.Unlock()
+
+	bindings := p.cfg.BindingsFor(lang)
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	for _, b := range bindings {
+		p.mu.Lock()
+		existing := p.backends[b.ServerID]
+		p.mu.Unlock()
+		if existing != nil {
+			continue
+		}
+		srv, ok := p.cfg.Servers[b.ServerID]
+		if !ok {
+			return fmt.Errorf("language %q references unknown server %q", lang, b.ServerID)
+		}
+		backend, err := StartBackend(ctx, p.root, b.ServerID, srv, p.onBackendMessage)
+		if err != nil {
+			return err
+		}
+		if err := p.initializeBackend(ctx, backend); err != nil {
+			backend.Close()
+			return fmt.Errorf("initialize %q: %w", b.ServerID, err)
+		}
+		// Replay open docs for this language.
+		for _, doc := range p.docs.ByLanguage(lang) {
+			_ = backend.Notify("textDocument/didOpen", map[string]any{
+				"textDocument": map[string]any{
+					"uri":        doc.URI,
+					"languageId": doc.LanguageID,
+					"version":    doc.Version,
+					"text":       doc.Text,
+				},
+			})
+		}
+		p.mu.Lock()
+		p.backends[b.ServerID] = backend
+		p.mu.Unlock()
+	}
+
+	p.mu.Lock()
+	p.langServers[lang] = bindings
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *Proxy) initializeBackend(ctx context.Context, backend *Backend) error {
+	// Build initialize params from client, forcing our root.
+	var base map[string]any
+	if len(p.initParams) > 0 {
+		_ = json.Unmarshal(p.initParams, &base)
+	}
+	if base == nil {
+		base = map[string]any{}
+	}
+	base["rootUri"] = p.rootURI
+	base["rootPath"] = p.root
+	base["workspaceFolders"] = []map[string]any{
+		{"uri": p.rootURI, "name": filepath.Base(p.root)},
+	}
+	// processId null so backends don't watch our pid incorrectly? Keep as is from client.
+
+	reqCtx, cancel := context.WithTimeout(ctx, p.timeout*2)
+	defer cancel()
+	resp, err := backend.Request(reqCtx, "initialize", base)
+	if err != nil {
+		return err
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("initialize error: %s", resp.Error.Message)
+	}
+	return backend.Notify("initialized", map[string]any{})
+}
+
+func (p *Proxy) onBackendMessage(serverID string, msg *Message) {
+	// Server->client notifications and requests: forward as-is (dogfood).
+	// For requests, we need to reply — v1 only forwards notifications to avoid ID chaos.
+	if msg.IsRequest() {
+		// Respond with method not found so backends don't hang; log.
+		_ = msg
+		go func() {
+			// Soft: ignore server-initiated requests for v1 (configuration etc. may break some servers).
+			// Try to answer workspace/configuration with empty items if we can.
+			if msg.Method == "workspace/configuration" {
+				var params struct {
+					Items []json.RawMessage `json:"items"`
+				}
+				_ = json.Unmarshal(msg.Params, &params)
+				result := make([]any, len(params.Items))
+				raw, _ := json.Marshal(result)
+				p.mu.Lock()
+				b := p.backends[serverID]
+				p.mu.Unlock()
+				if b != nil {
+					_ = b.conn.WriteMessage(&Message{
+						JSONRPC: "2.0",
+						ID:      msg.ID,
+						Result:  raw,
+					})
+				}
+				return
+			}
+			if msg.Method == "window/workDoneProgress/create" {
+				p.mu.Lock()
+				b := p.backends[serverID]
+				p.mu.Unlock()
+				if b != nil {
+					_ = b.conn.WriteMessage(&Message{
+						JSONRPC: "2.0",
+						ID:      msg.ID,
+						Result:  json.RawMessage("null"),
+					})
+				}
+				return
+			}
+			// client/registerCapability
+			if msg.Method == "client/registerCapability" || msg.Method == "client/unregisterCapability" {
+				p.mu.Lock()
+				b := p.backends[serverID]
+				p.mu.Unlock()
+				if b != nil {
+					_ = b.conn.WriteMessage(&Message{
+						JSONRPC: "2.0",
+						ID:      msg.ID,
+						Result:  json.RawMessage("null"),
+					})
+				}
+				return
+			}
+			logging.GetLogger(p.ctx).Debug("lsp ignoring backend request", "server", serverID, "method", msg.Method)
+		}()
+		return
+	}
+	// Notifications (diagnostics, logMessage, …)
+	_ = p.client.WriteMessage(msg)
+}
+
+func (p *Proxy) bindingsLive(lang string) []LanguageBinding {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.langServers[lang]
+}
+
+func (p *Proxy) getBackend(serverID string) *Backend {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.backends[serverID]
+}
+
+func (p *Proxy) closeAll() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for id, b := range p.backends {
+		// best-effort shutdown
+		_, _ = b.Request(context.Background(), "shutdown", nil)
+		_ = b.Notify("exit", nil)
+		b.Close()
+		delete(p.backends, id)
+	}
+	p.langServers = map[string][]LanguageBinding{}
+}
+
+func extractURI(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var probe struct {
+		TextDocument struct {
+			URI string `json:"uri"`
+		} `json:"textDocument"`
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &probe); err != nil {
+		return ""
+	}
+	if probe.TextDocument.URI != "" {
+		return probe.TextDocument.URI
+	}
+	return probe.URI
+}
+
+// RootFromURI is exported for tests.
+func RootFromURI(u string) (string, error) {
+	if strings.HasPrefix(u, "file://") {
+		parsed, err := url.Parse(u)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Abs(parsed.Path)
+	}
+	return filepath.Abs(u)
+}

--- a/internal/lsp/proxy_test.go
+++ b/internal/lsp/proxy_test.go
@@ -1,0 +1,165 @@
+package lsp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"workspaced/pkg/logging"
+)
+
+func writeLSP(t *testing.T, w io.Writer, v any) {
+	t.Helper()
+	body, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(w, "Content-Length: "); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(w, string(mustJSON(len(body)))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(w, "\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(body); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestProxyInitializeEmptyConfig(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	serverIn, clientToServer := io.Pipe()   // client writes → server reads
+	clientFromServer, serverOut := io.Pipe() // server writes → client reads
+
+	ctx, cancel := context.WithCancel(logging.NewWriterContext(io.Discard))
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, serverIn, serverOut)
+	}()
+
+	writeLSP(t, clientToServer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"processId":    nil,
+			"rootUri":      pathToURI(root),
+			"capabilities": map[string]any{},
+		},
+	})
+
+	conn := NewConn(clientFromServer, io.Discard)
+	msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Error != nil {
+		t.Fatalf("error: %+v", msg.Error)
+	}
+	if len(msg.Result) == 0 {
+		t.Fatal("empty result")
+	}
+	var result map[string]any
+	if err := json.Unmarshal(msg.Result, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["capabilities"] == nil {
+		t.Fatal("missing capabilities")
+	}
+
+	// hover with no backends -> method not found
+	writeLSP(t, clientToServer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "textDocument/hover",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": pathToURI(filepath.Join(root, "x.go"))},
+			"position":     map[string]any{"line": 0, "character": 0},
+		},
+	})
+	msg, err = conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Error == nil || msg.Error.Code != CodeMethodNotFound {
+		t.Fatalf("want MethodNotFound, got %+v result=%s", msg.Error, msg.Result)
+	}
+
+	_ = clientToServer.Close()
+	_ = serverOut.Close()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		cancel()
+	}
+}
+
+func TestProxyMultiRootRejected(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	serverIn, clientToServer := io.Pipe()
+	clientFromServer, serverOut := io.Pipe()
+
+	ctx, cancel := context.WithCancel(logging.NewWriterContext(io.Discard))
+	defer cancel()
+	go func() { _ = Run(ctx, serverIn, serverOut) }()
+
+	writeLSP(t, clientToServer, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"workspaceFolders": []map[string]any{
+				{"uri": pathToURI(root), "name": "a"},
+				{"uri": pathToURI(filepath.Join(root, "other")), "name": "b"},
+			},
+			"capabilities": map[string]any{},
+		},
+	})
+	conn := NewConn(clientFromServer, io.Discard)
+	msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Error == nil || !strings.Contains(msg.Error.Message, "single workspace") {
+		t.Fatalf("want multi-root error, got %+v", msg.Error)
+	}
+	_ = clientToServer.Close()
+	cancel()
+}
+
+func TestWriteReadFraming(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	c := NewConn(nil, &buf)
+	if err := c.WriteResult(json.RawMessage("1"), map[string]string{"ok": "yes"}); err != nil {
+		t.Fatal(err)
+	}
+	rc := NewConn(bytes.NewReader(buf.Bytes()), io.Discard)
+	msg, err := rc.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(msg.ID) != "1" {
+		t.Fatalf("id=%s", msg.ID)
+	}
+}


### PR DESCRIPTION
## Summary

**Experimental.** Adds `workspaced codebase lsp`: a stdio LSP proxy so editors talk to **one** process while cue owns language → server routing.

API, cue schema, and merge behavior may change without a migration path.

- **Config** (`workspaced.lsp` in codebase cue): extension map (wins first) + `language_ids` fallback → language → ordered servers (`00_gopls`, …) with capability maps; `servers` with `cmd` + optional `needs` → `lazy_tools`
- **Runtime**: single workspace root (multi-root errors); empty/missing `lsp` still initializes but methods return unsupported; full text sync; async fan-out; soft timeout per backend; array merge / first non-null; announce full capabilities, stub when nothing serves
- **CLI**: `workspaced codebase lsp` (stdout = wire, stderr = logs) — labeled experimental in `--help`

Dogfood path: wire the editor to this command, declare gopls (or any stdio server) under `lsp`, open a file.

## Example

```cue
workspaced: {
  lsp: {
    extensions: { ".go": "go" }
    language_ids: { go: "go", gomod: "go" }
    languages: {
      go: {
        "00_gopls": {
          capabilities: {
            hover: true
            definition: true
            completion: true
            diagnostics: true
          }
        }
      }
    }
    servers: {
      gopls: {
        cmd: ["gopls"]
        needs: { gopls: true }
      }
    }
  }
  lazy_tools: {
    gopls: { ref: "github:golang/tools/gopls" } // or whatever pin you use
  }
}
```

## Test plan

- [x] `go test ./internal/lsp/ ./internal/configcue/`
- [x] `workspaced codebase lsp --help` (shows experimental)
- [x] Smoke: framed `initialize` over stdio returns capabilities
- [ ] Editor dogfood: Helix/nvim single LS entry → gopls hover/diags on a Go repo
- [ ] Optional: second ordered server + soft-timeout behavior