### PR TITLE
fix(termux): resolve real home so shims work outside proot

### DIFF
--- a/cmd/workspaced/open/mise.go
+++ b/cmd/workspaced/open/mise.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/lucasew/workspaced/internal/miseutil"
+	envdriver "github.com/lucasew/workspaced/pkg/driver/env"
 	execdriver "github.com/lucasew/workspaced/pkg/driver/exec"
 	"github.com/lucasew/workspaced/pkg/driver/shim/bash"
 	"github.com/lucasew/workspaced/pkg/logging"
@@ -32,7 +33,7 @@ func ensureMise(ctx context.Context) (string, error) {
 // ensureMiseWrapper creates a wrapper script in ~/.local/bin/mise
 func ensureMiseWrapper(ctx context.Context, misePath string) error {
 	logger := logging.GetLogger(ctx)
-	home, err := os.UserHomeDir()
+	home, err := envdriver.ResolveHomeDir()
 	if err != nil {
 		return fmt.Errorf("get home directory: %w", err)
 	}

--- a/cmd/workspaced/selfinstall/root.go
+++ b/cmd/workspaced/selfinstall/root.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/lucasew/workspaced/internal/version"
+	envdriver "github.com/lucasew/workspaced/pkg/driver/env"
 	"github.com/lucasew/workspaced/pkg/driver/shim"
 	"github.com/lucasew/workspaced/pkg/logging"
 	"github.com/lucasew/workspaced/pkg/taskgroup"
@@ -58,13 +59,21 @@ func runSelfInstall(ctx context.Context, force bool) error {
 		return fmt.Errorf("failed to get current binary: %w", err)
 	}
 
-	// Determine install location (fixed path, not versioned)
-	home, err := os.UserHomeDir()
+	// Fixed install location under real home (not Termux proot /home view).
+	dataDir, err := envdriver.GetUserDataDir(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		// Bootstrap before drivers/weights: fall back to ResolveHomeDir.
+		home, homeErr := envdriver.ResolveHomeDir()
+		if homeErr != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		dataDir = filepath.Join(home, ".local", "share", "workspaced")
+		if mkErr := os.MkdirAll(dataDir, 0o755); mkErr != nil {
+			return fmt.Errorf("failed to create user data dir: %w", mkErr)
+		}
 	}
 
-	installDir := filepath.Join(home, ".local", "share", "workspaced", "bin")
+	installDir := filepath.Join(dataDir, "bin")
 	installPath := filepath.Join(installDir, "workspaced")
 
 	currentVersion := version.Version()
@@ -129,11 +138,15 @@ func createWorkspacedShim(ctx context.Context, workspacedPath string) error {
 
 func createMiseShim(ctx context.Context) error {
 	// Always create shim, even if mise not installed yet.
-	home, err := os.UserHomeDir()
+	dataDir, err := envdriver.GetUserDataDir(ctx)
 	if err != nil {
-		return err
+		home, homeErr := envdriver.ResolveHomeDir()
+		if homeErr != nil {
+			return err
+		}
+		dataDir = filepath.Join(home, ".local", "share", "workspaced")
 	}
-	misePath := filepath.Join(home, ".local", "share", "workspaced", "bin", "mise")
+	misePath := filepath.Join(dataDir, "bin", "mise")
 	shimPath, err := shim.GenerateInLocalBin(ctx, "mise", []string{misePath})
 	if err != nil {
 		return err

--- a/cmd/workspaced/selfupdate/root.go
+++ b/cmd/workspaced/selfupdate/root.go
@@ -102,14 +102,11 @@ func runSelfUpdate(ctx context.Context, force bool) error {
 // ============================================================================
 
 func buildAndInstallFromSource(ctx context.Context, srcPath string) error {
-	// Install to fixed location (not versioned)
-	home, err := os.UserHomeDir()
+	// Install to fixed location (not versioned); real home, not Termux /home chroot view.
+	installDir, installPath, err := workspacedInstallPaths(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return err
 	}
-
-	installDir := filepath.Join(home, ".local", "share", "workspaced", "bin")
-	installPath := filepath.Join(installDir, "workspaced")
 
 	goVersion := getGoVersion()
 	if goVersion == "" {
@@ -232,13 +229,11 @@ func updateFromGitHub(ctx context.Context, force bool) error {
 		return fmt.Errorf("%w: %s/%s (available: %v)", ErrNoArtifactFound, runtime.GOOS, runtime.GOARCH, available)
 	}
 
-	// Install to fixed location (not versioned)
-	home, err := os.UserHomeDir()
+	// Install to fixed location (not versioned); real home, not Termux /home chroot view.
+	installDir, _, err := workspacedInstallPaths(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return err
 	}
-
-	installDir := filepath.Join(home, ".local", "share", "workspaced", "bin")
 	tmpDir := filepath.Join(installDir, ".tmp-"+normalizedLatest)
 
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
@@ -360,6 +355,29 @@ func updateWorkspacedShim(ctx context.Context, workspacedPath string) error {
 	}
 	logging.GetLogger(ctx).Info("updated shim", "path", shimPath, "target", workspacedPath)
 	return nil
+}
+
+// workspacedInstallPaths returns the fixed bin dir and workspaced binary path
+// under the env driver's user data dir (ResolveHomeDir on Termux).
+func workspacedInstallPaths(ctx context.Context) (installDir, installPath string, err error) {
+	dataDir, err := envdriver.GetUserDataDir(ctx)
+	if err != nil {
+		home, homeErr := envdriver.ResolveHomeDir()
+		if homeErr != nil {
+			return "", "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		dataDir = filepath.Join(home, ".local", "share", "workspaced")
+		if mkErr := os.MkdirAll(dataDir, 0o755); mkErr != nil {
+			return "", "", fmt.Errorf("failed to create user data dir: %w", mkErr)
+		}
+	}
+	installDir = filepath.Join(dataDir, "bin")
+	name := "workspaced"
+	if runtime.GOOS == "windows" {
+		name = "workspaced.exe"
+	}
+	installPath = filepath.Join(installDir, name)
+	return installDir, installPath, nil
 }
 
 func findSourcePath(ctx context.Context) (string, error) {

--- a/internal/configcue/loader.go
+++ b/internal/configcue/loader.go
@@ -81,7 +81,7 @@ func DiscoverLayers(ctx context.Context, opts DiscoverOptions) (DiscoverResult, 
 	}
 
 	if opts.HomeMode {
-		homeDir, err := os.UserHomeDir()
+		homeDir, err := envdriver.ResolveHomeDir()
 		if err == nil && homeDir != "" {
 			p := filepath.Join(homeDir, "workspaced.cue")
 			if fileExists(p) {
@@ -781,9 +781,13 @@ func fileExists(path string) bool {
 }
 
 func buildRuntimePrelude(ctx context.Context, resolvedInputs map[string]map[string]any) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := envdriver.GetHomeDir(ctx)
 	if err != nil {
-		return "", fmt.Errorf("user home dir: %w", err)
+		// Fallback when drivers are not ready (early bootstrap).
+		home, err = envdriver.ResolveHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("user home dir: %w", err)
+		}
 	}
 	configDir, err := envdriver.GetConfigDir(ctx)
 	if err != nil {
@@ -859,7 +863,7 @@ func resolveRuntimeInputs(configValue cue.Value, paths []string, discovered []La
 
 	modulesBaseDir := resolvedSelfModulesBase(paths, discovered)
 	workspaceRoot := filepath.Dir(modulesBaseDir)
-	home, err := os.UserHomeDir()
+	home, err := envdriver.ResolveHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("user home dir: %w", err)
 	}

--- a/internal/miseutil/mise.go
+++ b/internal/miseutil/mise.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/lucasew/workspaced/internal/tool"
 	"github.com/lucasew/workspaced/pkg/driver"
+	envdriver "github.com/lucasew/workspaced/pkg/driver/env"
 	execdriver "github.com/lucasew/workspaced/pkg/driver/exec"
 	"github.com/lucasew/workspaced/pkg/driver/httpclient"
 	"github.com/lucasew/workspaced/pkg/driver/shim/bash"
@@ -36,7 +37,7 @@ func GetPath() string {
 		return path
 	}
 
-	home, err := os.UserHomeDir()
+	home, err := envdriver.ResolveHomeDir()
 	if err != nil {
 		return ""
 	}

--- a/internal/source/template_context.go
+++ b/internal/source/template_context.go
@@ -3,10 +3,10 @@ package source
 import (
 	"context"
 	"fmt"
+	"runtime"
+
 	"github.com/lucasew/workspaced/internal/configcue"
 	envdriver "github.com/lucasew/workspaced/pkg/driver/env"
-	"os"
-	"runtime"
 
 	"github.com/pbnjay/memory"
 )
@@ -34,9 +34,12 @@ func buildTemplateData(ctx context.Context, cfg *configcue.Config, f File) (map[
 		}
 	}
 
-	home, err := os.UserHomeDir()
+	home, err := envdriver.GetHomeDir(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("user home dir: %w", err)
+		home, err = envdriver.ResolveHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("user home dir: %w", err)
+		}
 	}
 	userDataDir, err := envdriver.GetUserDataDir(ctx)
 	if err != nil {

--- a/internal/tool/paths.go
+++ b/internal/tool/paths.go
@@ -1,14 +1,14 @@
 package tool
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/lucasew/workspaced/internal/tool/checks"
+	envdriver "github.com/lucasew/workspaced/pkg/driver/env"
 )
 
 func GetToolsDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := envdriver.ResolveHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -16,7 +16,7 @@ func GetToolsDir() (string, error) {
 }
 
 func GetShimsDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := envdriver.ResolveHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/driver/env/driver.go
+++ b/pkg/driver/env/driver.go
@@ -2,11 +2,12 @@ package env
 
 import (
 	"context"
-	"github.com/lucasew/workspaced/pkg/driver"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/lucasew/workspaced/pkg/driver"
 )
 
 // Driver provides platform-specific environment operations.
@@ -101,10 +102,10 @@ func IsInStore(ctx context.Context) bool {
 	return len(root) >= 10 && root[:10] == "/nix/store"
 }
 
-// ExpandPath expands ~ via os.UserHomeDir and $VAR via os.ExpandEnv.
+// ExpandPath expands ~ via ResolveHomeDir and $VAR via os.ExpandEnv.
 // Callers that know a driver-specific home should use ExpandPathIn instead.
 func ExpandPath(path string) string {
-	home, _ := os.UserHomeDir()
+	home, _ := ResolveHomeDir()
 	return ExpandPathIn(path, home)
 }
 

--- a/pkg/driver/env/home.go
+++ b/pkg/driver/env/home.go
@@ -1,0 +1,72 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultTermuxPrefix is used when PREFIX is unset but other Termux markers are present.
+const defaultTermuxPrefix = "/data/data/com.termux/files/usr"
+
+// ResolveHomeDir returns the real user home directory for path layout (shims,
+// tool store, self-install).
+//
+// On Termux, $HOME is often "/home" inside proot/termux-chroot (root is
+// $PREFIX/..). Paths baked that way break outside proot. When Termux is
+// detected, "/home" (and empty HOME) are rewritten to $PREFIX/../home.
+func ResolveHomeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// UserHomeDir fails when HOME is unset and passwd lookup fails.
+		// Still try Termux rewrite from PREFIX alone.
+		if fixed, ok := termuxHomeFromPrefix(); ok {
+			return fixed, nil
+		}
+		return "", err
+	}
+	return NormalizeHome(home), nil
+}
+
+// NormalizeHome rewrites known Termux chroot home views to absolute paths.
+// Non-Termux environments are returned unchanged.
+func NormalizeHome(home string) string {
+	if !IsTermuxLike() {
+		return home
+	}
+	if home == "" || home == "/home" {
+		if fixed, ok := termuxHomeFromPrefix(); ok {
+			return fixed
+		}
+	}
+	return home
+}
+
+// IsTermuxLike reports whether the process looks like Termux (or workspaced
+// proot-inside-Termux), so home path normalization should apply.
+func IsTermuxLike() bool {
+	if os.Getenv("TERMUX_VERSION") != "" {
+		return true
+	}
+	if os.Getenv("TERMUX_APP_PACKAGE") != "" {
+		return true
+	}
+	if os.Getenv("WORKSPACED_IN_PROOT") == "1" {
+		return true
+	}
+	prefix := os.Getenv("PREFIX")
+	return strings.HasPrefix(prefix, "/data/data/com.termux/files")
+}
+
+func termuxHomeFromPrefix() (string, bool) {
+	prefix := os.Getenv("PREFIX")
+	if prefix == "" {
+		if !IsTermuxLike() {
+			return "", false
+		}
+		prefix = defaultTermuxPrefix
+	}
+	// PREFIX is .../files/usr → home is .../files/home
+	home := filepath.Join(filepath.Dir(prefix), "home")
+	return home, true
+}

--- a/pkg/driver/env/home_test.go
+++ b/pkg/driver/env/home_test.go
@@ -1,0 +1,71 @@
+package env_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lucasew/workspaced/pkg/driver/env"
+)
+
+func TestNormalizeHomeTermuxChroot(t *testing.T) {
+	t.Setenv("TERMUX_VERSION", "0.118.3")
+	t.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+	t.Setenv("HOME", "/home")
+
+	got := env.NormalizeHome("/home")
+	want := "/data/data/com.termux/files/home"
+	if got != want {
+		t.Fatalf("NormalizeHome(/home) = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeHomeTermuxAlreadyAbsolute(t *testing.T) {
+	t.Setenv("TERMUX_VERSION", "0.118.3")
+	t.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+	realHome := "/data/data/com.termux/files/home"
+	got := env.NormalizeHome(realHome)
+	if got != realHome {
+		t.Fatalf("NormalizeHome(real) = %q, want %q", got, realHome)
+	}
+}
+
+func TestNormalizeHomeNonTermuxLeavesHome(t *testing.T) {
+	t.Setenv("TERMUX_VERSION", "")
+	t.Setenv("TERMUX_APP_PACKAGE", "")
+	t.Setenv("WORKSPACED_IN_PROOT", "")
+	t.Setenv("PREFIX", "/usr")
+	got := env.NormalizeHome("/home")
+	if got != "/home" {
+		t.Fatalf("NormalizeHome on non-Termux = %q, want /home", got)
+	}
+}
+
+func TestResolveHomeDirTermux(t *testing.T) {
+	t.Setenv("TERMUX_VERSION", "0.118.3")
+	t.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+	t.Setenv("HOME", "/home")
+
+	got, err := env.ResolveHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/data/data/com.termux/files", "home")
+	if got != want {
+		t.Fatalf("ResolveHomeDir = %q, want %q", got, want)
+	}
+}
+
+func TestIsTermuxLike(t *testing.T) {
+	t.Setenv("TERMUX_VERSION", "")
+	t.Setenv("TERMUX_APP_PACKAGE", "")
+	t.Setenv("WORKSPACED_IN_PROOT", "")
+	t.Setenv("PREFIX", "/usr")
+	if env.IsTermuxLike() {
+		t.Fatal("expected false without markers")
+	}
+
+	t.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+	if !env.IsTermuxLike() {
+		t.Fatal("expected true with Termux PREFIX")
+	}
+}

--- a/pkg/driver/env/native/provider.go
+++ b/pkg/driver/env/native/provider.go
@@ -20,7 +20,9 @@ func (f *Factory) New(ctx context.Context) (envdriver.Driver, error) { return &D
 
 type Driver struct{}
 
-func (d *Driver) GetHomeDir(ctx context.Context) (string, error) { return os.UserHomeDir() }
+func (d *Driver) GetHomeDir(ctx context.Context) (string, error) {
+	return envdriver.ResolveHomeDir()
+}
 
 func (d *Driver) GetDotfilesRoot(ctx context.Context) (string, error) {
 	home, err := d.GetHomeDir(ctx)

--- a/pkg/driver/env/termux/provider.go
+++ b/pkg/driver/env/termux/provider.go
@@ -27,15 +27,7 @@ func (f *Factory) New(ctx context.Context) (envdriver.Driver, error) { return &D
 type Driver struct{}
 
 func (d *Driver) GetHomeDir(ctx context.Context) (string, error) {
-	home := os.Getenv("HOME")
-	if home == "" || home == "/home" {
-		prefix := os.Getenv("PREFIX")
-		if prefix == "" {
-			prefix = "/data/data/com.termux/files/usr"
-		}
-		home = filepath.Join(filepath.Dir(prefix), "home")
-	}
-	return home, nil
+	return envdriver.ResolveHomeDir()
 }
 
 func (d *Driver) GetDotfilesRoot(ctx context.Context) (string, error) {

--- a/pkg/driver/shim/driver.go
+++ b/pkg/driver/shim/driver.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/lucasew/workspaced/pkg/driver"
+	envdriver "github.com/lucasew/workspaced/pkg/driver/env"
 )
 
 var (
@@ -42,8 +44,9 @@ func Generate(ctx context.Context, path string, command []string) error {
 }
 
 // LocalBinDir returns ~/.local/bin for the current user.
+// Uses env.ResolveHomeDir so Termux proot HOME=/home is expanded to the real path.
 func LocalBinDir() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := envdriver.ResolveHomeDir()
 	if err != nil {
 		return "", err
 	}
@@ -53,6 +56,9 @@ func LocalBinDir() (string, error) {
 // GenerateInLocalBin ensures ~/.local/bin exists and writes an executable shim
 // named name that runs command. Returns the absolute shim path. Callers own
 // success logging so install vs update wording stays at the call site.
+//
+// command paths should already be absolute real paths (not Termux chroot views);
+// self-install uses ResolveHomeDir for that reason.
 func GenerateInLocalBin(ctx context.Context, name string, command []string) (string, error) {
 	if name == "" {
 		return "", ErrEmptyName
@@ -63,6 +69,17 @@ func GenerateInLocalBin(ctx context.Context, name string, command []string) (str
 	if filepath.Base(name) != name || name == "." || name == ".." {
 		return "", fmt.Errorf("shim name %q must be a plain base name", name)
 	}
+
+	// Normalize absolute command targets so shims stay valid outside proot.
+	normalized := make([]string, len(command))
+	for i, arg := range command {
+		if i == 0 && filepath.IsAbs(arg) {
+			normalized[i] = normalizeAbsHomePath(arg)
+		} else {
+			normalized[i] = arg
+		}
+	}
+	command = normalized
 
 	localBin, err := LocalBinDir()
 	if err != nil {
@@ -77,4 +94,21 @@ func GenerateInLocalBin(ctx context.Context, name string, command []string) (str
 		return "", err
 	}
 	return shimPath, nil
+}
+
+// normalizeAbsHomePath rewrites a Termux chroot absolute path that starts with
+// /home/ to the real $PREFIX/../home/... so the baked exec target works outside proot.
+func normalizeAbsHomePath(path string) string {
+	home, err := envdriver.ResolveHomeDir()
+	if err != nil || home == "" || home == "/home" {
+		return path
+	}
+	const chrootHome = "/home"
+	if path == chrootHome {
+		return home
+	}
+	if strings.HasPrefix(path, chrootHome+"/") {
+		return home + path[len(chrootHome):]
+	}
+	return path
 }

--- a/pkg/driver/shim/localbin_test.go
+++ b/pkg/driver/shim/localbin_test.go
@@ -15,6 +15,10 @@ import (
 func TestGenerateInLocalBin(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("TERMUX_VERSION", "")
+	t.Setenv("TERMUX_APP_PACKAGE", "")
+	t.Setenv("WORKSPACED_IN_PROOT", "")
+	t.Setenv("PREFIX", "")
 	ctx := logging.NewWriterContext(t.Output())
 	target := filepath.Join(home, "opt", "workspaced")
 
@@ -67,6 +71,11 @@ func TestGenerateInLocalBinValidation(t *testing.T) {
 func TestLocalBinDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// Ensure Termux rewrite does not apply in unit tests.
+	t.Setenv("TERMUX_VERSION", "")
+	t.Setenv("TERMUX_APP_PACKAGE", "")
+	t.Setenv("WORKSPACED_IN_PROOT", "")
+	t.Setenv("PREFIX", "")
 
 	got, err := shim.LocalBinDir()
 	if err != nil {
@@ -75,5 +84,39 @@ func TestLocalBinDir(t *testing.T) {
 	want := filepath.Join(home, ".local", "bin")
 	if got != want {
 		t.Fatalf("LocalBinDir: got %q want %q", got, want)
+	}
+}
+
+func TestGenerateInLocalBinRewritesTermuxChrootTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", "/home")
+	t.Setenv("TERMUX_VERSION", "0.118.3")
+	t.Setenv("PREFIX", filepath.Join(home, "usr"))
+	// Real home is PREFIX/../home; create it so layout stays under temp.
+	realHome := filepath.Join(home, "home")
+	if err := os.MkdirAll(filepath.Join(realHome, ".local", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Point PREFIX so ResolveHomeDir → <home>/home
+	t.Setenv("PREFIX", filepath.Join(home, "usr"))
+
+	ctx := logging.NewWriterContext(t.Output())
+	// Target as seen inside proot
+	chrootTarget := "/home/.local/share/workspaced/bin/workspaced"
+	shimPath, err := shim.GenerateInLocalBin(ctx, "workspaced", []string{chrootTarget})
+	if err != nil {
+		t.Fatalf("GenerateInLocalBin: %v", err)
+	}
+
+	content, err := os.ReadFile(shimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTarget := filepath.Join(realHome, ".local", "share", "workspaced", "bin", "workspaced")
+	if !strings.Contains(string(content), wantTarget) {
+		t.Fatalf("shim should rewrite chroot target to %q, got:\n%s", wantTarget, content)
+	}
+	if strings.Contains(string(content), "exec /home/.local/") {
+		t.Fatalf("shim still has chroot path:\n%s", content)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `env.ResolveHomeDir` / `NormalizeHome` so Termux proot/chroot `HOME=/home` is rewritten to `$PREFIX/../home` (the real path outside proot).
- Route self-install, self-update, shim layout, tool/mise paths, and `runtime.home` through that resolution so baked shims do not point at `/home/.local/share/workspaced/bin/workspaced`.
- `GenerateInLocalBin` also rewrites absolute exec targets that start with `/home/` so regenerating shims fixes already-bad targets.

## Context

On Termux, running under proot makes home appear as `/home`. Install still writes into the real tree, but PATH shims baked `exec /home/.local/share/workspaced/bin/workspaced`, which fails with ENOENT in a normal Termux session even when the binary exists at `/data/data/com.termux/files/home/.local/share/workspaced/bin/workspaced`.

## Test plan

- [x] `mise exec -- go test ./pkg/driver/env/ ./pkg/driver/shim/ ./internal/tool/ ./internal/source/ ./internal/configcue/ -count=1`
- [x] `mise exec -- go build ./cmd/workspaced`
- [ ] On Termux: build/install this branch, run `workspaced self-install --force`, confirm `head -5 ~/.local/bin/workspaced` uses the full `/data/data/com.termux/files/home/...` path (not `/home/...`)
- [ ] `workspaced --version` via `~/.local/bin/workspaced` succeeds