### PR TITLE
feat(apply): skip state for gitignored dests

### DIFF
--- a/cmd/workspaced/codebase/apply.go
+++ b/cmd/workspaced/codebase/apply.go
@@ -132,6 +132,7 @@ func Schedule(g *taskgroup.Group, cmd *cobra.Command, dryRun, showNoop bool) fun
 		mgr, err := dotfiles.NewManager(dotfiles.Config{
 			Pipeline:   pipeline,
 			StateStore: stateStore,
+			Ignore:     deployer.GitignoreUntracked(workspaceRoot),
 			// No home-specific hooks (dconf, gtk, etc.)
 		})
 		if err != nil {

--- a/internal/deployer/executor.go
+++ b/internal/deployer/executor.go
@@ -67,16 +67,25 @@ func PrettyPath(path string) string {
 }
 
 // Executor applies deployment actions.
-type Executor struct{}
+type Executor struct {
+	// Ignore, if set, is true for targets that must not appear in state
+	// after create/update (typically gitignored paths).
+	Ignore func(target string) bool
+}
 
 // NewExecutor creates a new Executor.
 func NewExecutor() *Executor {
 	return &Executor{}
 }
 
+func (e *Executor) skipState(target string) bool {
+	return e != nil && e.Ignore != nil && e.Ignore(target)
+}
+
 // statePatch is the pure state delta produced by applying one action's filesystem work.
 type statePatch struct {
 	delete bool
+	skip   bool // create/update of an ignored path: drop any existing key
 	target string
 	info   ManagedInfo
 }
@@ -85,7 +94,7 @@ func applyPatch(state *State, p statePatch) {
 	if state == nil {
 		return
 	}
-	if p.delete {
+	if p.delete || p.skip {
 		delete(state.Files, p.target)
 		return
 	}
@@ -132,6 +141,7 @@ func (e *Executor) Execute(ctx context.Context, actions []Action, state *State) 
 			}
 
 			info := ManagedInfo{SourceInfo: action.Desired.File.SourceInfo()}
+			skip := e.skipState(action.Target)
 			if action.Desired.File.Type() == source.TypeSymlink {
 				if _, err := os.Lstat(action.Target); err == nil {
 					if err := os.RemoveAll(action.Target); err != nil {
@@ -145,7 +155,7 @@ func (e *Executor) Execute(ctx context.Context, actions []Action, state *State) 
 				if err := os.Symlink(linkTarget, action.Target); err != nil {
 					return statePatch{}, fmt.Errorf("create symlink %s -> %s: %w", action.Target, linkTarget, err)
 				}
-				return statePatch{target: action.Target, info: info}, nil
+				return statePatch{target: action.Target, info: info, skip: skip}, nil
 			}
 
 			// Replace non-regular targets (dirs/symlinks) so rename can install a file.
@@ -166,7 +176,7 @@ func (e *Executor) Execute(ctx context.Context, actions []Action, state *State) 
 			if writeErr != nil {
 				return statePatch{}, fmt.Errorf("write content to %s: %w", action.Target, writeErr)
 			}
-			return statePatch{target: action.Target, info: info}, nil
+			return statePatch{target: action.Target, info: info, skip: skip}, nil
 		}
 		return statePatch{}, nil
 	}

--- a/internal/deployer/executor_test.go
+++ b/internal/deployer/executor_test.go
@@ -157,3 +157,49 @@ func TestExecuteWritesRegularFile(t *testing.T) {
 		t.Fatalf("state not updated: %+v", state.Files)
 	}
 }
+
+func TestExecuteIgnoredCreateOmitsState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "placed.md")
+	content := []byte("hello ignore\n")
+	ex := NewExecutor()
+	ex.Ignore = func(path string) bool { return path == target }
+
+	actions := []Action{{
+		Type:   ActionCreate,
+		Target: target,
+		Desired: DesiredState{
+			File: &source.BufferFile{
+				BasicFile: source.BasicFile{
+					RelPathStr:    "placed.md",
+					TargetBaseDir: dir,
+					FileMode:      0o644,
+					Info:          "module:place (placed.md)",
+					FileType:      source.TypeStatic,
+				},
+				Content: content,
+			},
+		},
+	}}
+	state := &State{Files: map[string]ManagedInfo{
+		target: {SourceInfo: "old"},
+	}}
+
+	g, ctx := taskgroup.New(logging.NewWriterContext(t.Output()), taskgroup.DefaultLimits())
+	_ = g
+	if err := ex.Execute(ctx, actions, state); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("got %q want %q", got, content)
+	}
+	if _, ok := state.Files[target]; ok {
+		t.Fatalf("ignored path still in state: %+v", state.Files)
+	}
+}

--- a/internal/deployer/ignore.go
+++ b/internal/deployer/ignore.go
@@ -1,0 +1,107 @@
+package deployer
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/git-pkgs/gitignore"
+)
+
+// GitignoreUntracked returns a predicate that is true when absTarget is
+// ignored by the git worktree at root (.gitignore files and .git/info/exclude).
+// It does not load global core.excludesfile (apply ownership must not depend
+// on the operator's user git config).
+//
+// Returns nil when root is not a git worktree. The matcher is safe for
+// concurrent Match calls after return.
+func GitignoreUntracked(root string) func(absTarget string) bool {
+	root = filepath.Clean(root)
+	if root == "" || root == "." {
+		return nil
+	}
+	if !isGitWorkTree(root) {
+		return nil
+	}
+	m := loadRepoIgnore(root)
+	return func(absTarget string) bool {
+		rel := RelToRoot(absTarget, root)
+		if rel == absTarget || rel == "." || rel == "" {
+			return false
+		}
+		return m.MatchPath(filepath.ToSlash(rel), false)
+	}
+}
+
+// DropIgnored removes state entries for which ignore(target) is true.
+// Returns how many keys were dropped. ignore nil is a no-op.
+func DropIgnored(state *State, ignore func(string) bool) int {
+	if state == nil || state.Files == nil || ignore == nil {
+		return 0
+	}
+	n := 0
+	for target := range state.Files {
+		if ignore(target) {
+			delete(state.Files, target)
+			n++
+		}
+	}
+	return n
+}
+
+func isGitWorkTree(root string) bool {
+	st, err := os.Lstat(filepath.Join(root, ".git"))
+	if err != nil {
+		return false
+	}
+	return st.IsDir() || st.Mode().IsRegular()
+}
+
+func loadRepoIgnore(root string) *gitignore.Matcher {
+	m := gitignore.New("")
+
+	exclude := filepath.Join(root, ".git", "info", "exclude")
+	if data, err := os.ReadFile(exclude); err == nil {
+		m.AddPatterns(data, "")
+	}
+	rootGI := filepath.Join(root, ".gitignore")
+	if data, err := os.ReadFile(rootGI); err == nil {
+		m.AddPatterns(data, "")
+	}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			if m.MatchPath(rel, true) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != ".gitignore" {
+			return nil
+		}
+		dirRel := filepath.ToSlash(filepath.Dir(rel))
+		if dirRel == "." {
+			return nil
+		}
+		m.AddFromFile(path, dirRel)
+		return nil
+	})
+	if err != nil {
+		return m
+	}
+	return m
+}

--- a/internal/deployer/ignore_test.go
+++ b/internal/deployer/ignore_test.go
@@ -1,0 +1,114 @@
+package deployer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGitWorkTree(t *testing.T, gitignore string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if gitignore != "" {
+		if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(gitignore), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestGitignoreUntrackedNilWithoutGit(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".grok/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := GitignoreUntracked(root); got != nil {
+		t.Fatal("expected nil ignore without .git")
+	}
+}
+
+func TestGitignoreUntrackedMatchesRepoIgnore(t *testing.T) {
+	t.Parallel()
+	root := writeGitWorkTree(t, ".grok/\n*.local\n!keep.local\n")
+	ignore := GitignoreUntracked(root)
+	if ignore == nil {
+		t.Fatal("expected ignore fn")
+	}
+
+	tests := []struct {
+		rel  string
+		want bool
+	}{
+		{".grok/skills/foo.md", true},
+		{"keep.local", false},
+		{"foo.local", true},
+		{"README.md", false},
+	}
+	for _, tt := range tests {
+		got := ignore(filepath.Join(root, filepath.FromSlash(tt.rel)))
+		if got != tt.want {
+			t.Errorf("ignore(%q)=%v want %v", tt.rel, got, tt.want)
+		}
+	}
+	if ignore(filepath.Join(t.TempDir(), "outside")) {
+		t.Error("path outside root should not be ignored")
+	}
+}
+
+func TestGitignoreUntrackedNestedAndExclude(t *testing.T) {
+	t.Parallel()
+	root := writeGitWorkTree(t, "")
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "info", "exclude"), []byte("scratch/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(root, "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, ".gitignore"), []byte("gen/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ignore := GitignoreUntracked(root)
+	if ignore == nil {
+		t.Fatal("expected ignore fn")
+	}
+	if !ignore(filepath.Join(root, "scratch", "a.txt")) {
+		t.Error("info/exclude scratch/ should ignore")
+	}
+	if !ignore(filepath.Join(root, "pkg", "gen", "out.go")) {
+		t.Error("nested pkg/.gitignore gen/ should ignore")
+	}
+	if ignore(filepath.Join(root, "pkg", "main.go")) {
+		t.Error("pkg/main.go should not be ignored")
+	}
+}
+
+func TestDropIgnored(t *testing.T) {
+	t.Parallel()
+	root := writeGitWorkTree(t, ".grok/\n")
+	ignore := GitignoreUntracked(root)
+	tracked := filepath.Join(root, "README.md")
+	untracked := filepath.Join(root, ".grok", "a.md")
+	state := &State{Files: map[string]ManagedInfo{
+		tracked:   {SourceInfo: "a"},
+		untracked: {SourceInfo: "b"},
+	}}
+	n := DropIgnored(state, ignore)
+	if n != 1 {
+		t.Fatalf("dropped %d want 1", n)
+	}
+	if _, ok := state.Files[tracked]; !ok {
+		t.Fatal("tracked key dropped")
+	}
+	if _, ok := state.Files[untracked]; ok {
+		t.Fatal("ignored key still in state")
+	}
+}

--- a/internal/deployer/planner.go
+++ b/internal/deployer/planner.go
@@ -15,11 +15,20 @@ import (
 )
 
 // Planner compares current state with desired state and generates actions.
-type Planner struct{}
+type Planner struct {
+	// Ignore, if set, is true for targets that must not be adopted into state
+	// (typically gitignored paths). Content still converges; equal content is
+	// a noop instead of an adopt-update.
+	Ignore func(target string) bool
+}
 
 // NewPlanner creates a new Planner.
 func NewPlanner() *Planner {
 	return &Planner{}
+}
+
+func (p *Planner) ignored(target string) bool {
+	return p != nil && p.Ignore != nil && p.Ignore(target)
 }
 
 func calculateHash(r io.Reader) (string, error) {
@@ -30,7 +39,7 @@ func calculateHash(r io.Reader) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-func planOne(ctx context.Context, target string, d DesiredState, current ManagedInfo, managed bool) (Action, error) {
+func planOne(ctx context.Context, target string, d DesiredState, current ManagedInfo, managed, ignored bool) (Action, error) {
 	info, err := os.Lstat(target)
 	exists := err == nil
 
@@ -99,6 +108,9 @@ func planOne(ctx context.Context, target string, d DesiredState, current Managed
 	if needsUpdate {
 		return Action{Type: ActionUpdate, Target: target, Desired: d, Current: current}, nil
 	}
+	if ignored {
+		return Action{Type: ActionNoop, Target: target, Desired: d, Current: current}, nil
+	}
 	if !managed || current.SourceInfo != d.File.SourceInfo() {
 		return Action{Type: ActionUpdate, Target: target, Desired: d, Current: current}, nil
 	}
@@ -121,7 +133,7 @@ func (p *Planner) Plan(ctx context.Context, desired []DesiredState, currentState
 			target := ds.Target()
 			s.Update(target)
 			current, managed := currentState.Files[target]
-			return planOne(ctx, target, ds, current, managed)
+			return planOne(ctx, target, ds, current, managed, p.ignored(target))
 		},
 	}.Run(ctx)
 	if err != nil {

--- a/internal/deployer/planner_test.go
+++ b/internal/deployer/planner_test.go
@@ -99,3 +99,96 @@ func TestPlannerNoCacheForcesUpdateOnIdenticalContent(t *testing.T) {
 		t.Fatalf("no-cache want update, got %#v", actions)
 	}
 }
+
+func TestPlannerIgnoredEqualIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "placed.md")
+	content := []byte("hello\n")
+	if err := os.WriteFile(target, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desired := []DesiredState{{
+		File: &source.BufferFile{
+			BasicFile: source.BasicFile{
+				RelPathStr:    "placed.md",
+				TargetBaseDir: dir,
+				FileMode:      0o644,
+				Info:          "module:place (placed.md)",
+				FileType:      source.TypeStatic,
+			},
+			Content: content,
+		},
+	}}
+	state := &State{Files: map[string]ManagedInfo{}}
+	p := NewPlanner()
+	p.Ignore = func(path string) bool { return path == target }
+
+	g, ctx := taskgroup.New(logging.ContextWithLogger(t.Context(), slog.Default()), taskgroup.DefaultLimits())
+	_ = g
+	actions, err := p.Plan(ctx, desired, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 || actions[0].Type != ActionNoop {
+		t.Fatalf("want noop, got %#v", actions)
+	}
+}
+
+func TestPlannerIgnoredMissingIsCreate(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "placed.md")
+	desired := []DesiredState{{
+		File: &source.BufferFile{
+			BasicFile: source.BasicFile{
+				RelPathStr:    "placed.md",
+				TargetBaseDir: dir,
+				FileMode:      0o644,
+				Info:          "module:place (placed.md)",
+				FileType:      source.TypeStatic,
+			},
+			Content: []byte("hello\n"),
+		},
+	}}
+	p := NewPlanner()
+	p.Ignore = func(path string) bool { return path == target }
+
+	g, ctx := taskgroup.New(logging.ContextWithLogger(t.Context(), slog.Default()), taskgroup.DefaultLimits())
+	_ = g
+	actions, err := p.Plan(ctx, desired, &State{Files: map[string]ManagedInfo{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 || actions[0].Type != ActionCreate {
+		t.Fatalf("want create, got %#v", actions)
+	}
+}
+
+func TestPlannerUnmanagedEqualStillAdopts(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "tracked.md")
+	content := []byte("hello\n")
+	if err := os.WriteFile(target, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desired := []DesiredState{{
+		File: &source.BufferFile{
+			BasicFile: source.BasicFile{
+				RelPathStr:    "tracked.md",
+				TargetBaseDir: dir,
+				FileMode:      0o644,
+				Info:          "module:x (tracked.md)",
+				FileType:      source.TypeStatic,
+			},
+			Content: content,
+		},
+	}}
+	g, ctx := taskgroup.New(logging.ContextWithLogger(t.Context(), slog.Default()), taskgroup.DefaultLimits())
+	_ = g
+	actions, err := NewPlanner().Plan(ctx, desired, &State{Files: map[string]ManagedInfo{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 || actions[0].Type != ActionUpdate {
+		t.Fatalf("want adopt update, got %#v", actions)
+	}
+}

--- a/internal/dotfiles/manager.go
+++ b/internal/dotfiles/manager.go
@@ -24,6 +24,7 @@ type Manager struct {
 	planner    *deployer.Planner
 	executor   *deployer.Executor
 	hooks      []Hook
+	ignore     func(string) bool
 }
 
 // Config configures the Manager.
@@ -36,6 +37,10 @@ type Config struct {
 
 	// Hooks (optional).
 	Hooks []Hook
+
+	// Ignore, if set, is true for targets that must not appear in managed
+	// state (typically gitignored paths under the apply root).
+	Ignore func(target string) bool
 }
 
 // NewManager creates a new Manager.
@@ -48,12 +53,17 @@ func NewManager(cfg Config) (*Manager, error) {
 		return nil, ErrStateStoreRequired
 	}
 
+	planner := deployer.NewPlanner()
+	planner.Ignore = cfg.Ignore
+	executor := deployer.NewExecutor()
+	executor.Ignore = cfg.Ignore
 	return &Manager{
 		pipeline:   cfg.Pipeline,
 		stateStore: cfg.StateStore,
-		planner:    deployer.NewPlanner(),
-		executor:   deployer.NewExecutor(),
+		planner:    planner,
+		executor:   executor,
 		hooks:      cfg.Hooks,
+		ignore:     cfg.Ignore,
 	}, nil
 }
 
@@ -111,6 +121,11 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 		return result, fmt.Errorf("load state: %w", err)
 	}
 
+	dropped := deployer.DropIgnored(state, m.ignore)
+	if dropped > 0 {
+		logger.Info("dropping gitignored paths from state", "count", dropped)
+	}
+
 	// 4. Plan actions
 	logger.Info("planning actions")
 	planStart := time.Now()
@@ -141,6 +156,12 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 
 	if !hasChanges {
 		logger.Info("no changes needed")
+		if dropped > 0 && !opts.DryRun {
+			if err := m.stateStore.Save(state); err != nil {
+				result.Error = err
+				return result, fmt.Errorf("save state: %w", err)
+			}
+		}
 		return result, nil
 	}
 

--- a/skills/workspaced/references/plan-and-apply.md
+++ b/skills/workspaced/references/plan-and-apply.md
@@ -76,6 +76,7 @@ If plan is empty but you expected changes:
 - Lock/source resolution not updated
 - Template `skip`/conditionals suppressing output
 - Change only in an untracked file outside module layout
+- Codebase apply: gitignored dests (repo `.gitignore` / `.git/info/exclude`) still create/update on disk but are omitted from `state.json` and are never pruned. Home apply does not use this.
 
 ## Gotchas
 


### PR DESCRIPTION
## What

Codebase apply still writes gitignored dests, but those paths no longer go into `state.json` and are never pruned.

Ignore rules come from the apply-root repo: `.gitignore` (including nested) and `.git/info/exclude`. Global `core.excludesfile` is not loaded.

Home apply is unchanged.

## Why

`core:place` can dump a lot of files into the tree (skills, generated agent files). Tracking every one in state makes apply own and later delete them. If git already ignores the dest, workspaced should not claim it.

## Verify

- `go test ./internal/deployer/ ./internal/dotfiles/`
- `go build ./cmd/workspaced/`

## Follow-up for callers

Put place dests in `.gitignore`, then run `workspaced codebase apply` once so old keys drop out of state.