### PR TITLE
fix(apply): persist gitignore state drops

### DIFF
--- a/internal/deployer/ignore.go
+++ b/internal/deployer/ignore.go
@@ -20,12 +20,13 @@ func GitignoreUntracked(root string) func(absTarget string) bool {
 	if root == "" || root == "." {
 		return nil
 	}
-	if !isGitWorkTree(root) {
+	gitRoot := findGitRoot(root)
+	if gitRoot == "" {
 		return nil
 	}
-	m := loadRepoIgnore(root)
+	m := loadRepoIgnore(gitRoot)
 	return func(absTarget string) bool {
-		rel := RelToRoot(absTarget, root)
+		rel := RelToRoot(absTarget, gitRoot)
 		if rel == absTarget || rel == "." || rel == "" {
 			return false
 		}
@@ -47,6 +48,20 @@ func DropIgnored(state *State, ignore func(string) bool) int {
 		}
 	}
 	return n
+}
+
+func findGitRoot(start string) string {
+	dir := filepath.Clean(start)
+	for {
+		if isGitWorkTree(dir) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 func isGitWorkTree(root string) bool {

--- a/internal/deployer/ignore_test.go
+++ b/internal/deployer/ignore_test.go
@@ -20,6 +20,25 @@ func writeGitWorkTree(t *testing.T, gitignore string) string {
 	return root
 }
 
+func TestGitignoreUntrackedWalksUpToGitRoot(t *testing.T) {
+	t.Parallel()
+	gitRoot := writeGitWorkTree(t, ".grok/\n")
+	nested := filepath.Join(gitRoot, "apps", "svc")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ignore := GitignoreUntracked(nested)
+	if ignore == nil {
+		t.Fatal("expected ignore fn from parent git root")
+	}
+	if !ignore(filepath.Join(nested, ".grok", "skill.md")) {
+		t.Fatal("nested .grok path should match parent .gitignore")
+	}
+	if ignore(filepath.Join(nested, "main.go")) {
+		t.Fatal("nested tracked path should not be ignored")
+	}
+}
+
 func TestGitignoreUntrackedNilWithoutGit(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/dotfiles/manager.go
+++ b/internal/dotfiles/manager.go
@@ -79,6 +79,9 @@ type ApplyResult struct {
 	FilesUpdated int
 	FilesDeleted int
 	FilesNoOp    int
+	// StateDropped is how many existing state.json keys were removed because
+	// they are gitignored. Plan reports this without writing; apply persists it.
+	StateDropped int
 	Actions      []deployer.Action
 	// Warnings are soft diagnostics from module resolve (e.g. place move).
 	Warnings []string
@@ -122,6 +125,7 @@ func (m *Manager) Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, e
 	}
 
 	dropped := deployer.DropIgnored(state, m.ignore)
+	result.StateDropped = dropped
 	if dropped > 0 {
 		logger.Info("dropping gitignored paths from state", "count", dropped)
 	}

--- a/internal/dotfiles/manager_test.go
+++ b/internal/dotfiles/manager_test.go
@@ -1,0 +1,120 @@
+package dotfiles
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lucasew/workspaced/internal/deployer"
+	"github.com/lucasew/workspaced/internal/source"
+	"github.com/lucasew/workspaced/pkg/logging"
+	"github.com/lucasew/workspaced/pkg/taskgroup"
+)
+
+type fileListPlugin struct {
+	files []source.File
+}
+
+func (p fileListPlugin) Name() string { return "files" }
+
+func (p fileListPlugin) Process(_ context.Context, files []source.File) ([]source.File, error) {
+	out := append([]source.File{}, files...)
+	return append(out, p.files...), nil
+}
+
+func TestApplyPersistsDropOfGitignoredStateOnIdle(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ignoredRel := filepath.Join(".grok", "old.md")
+	keptRel := "README.md"
+	ignoredAbs := filepath.Join(root, ignoredRel)
+	keptAbs := filepath.Join(root, keptRel)
+	content := []byte("same\n")
+	for _, p := range []string{ignoredAbs, keptAbs} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st, err := os.Stat(keptAbs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode := st.Mode()
+
+	pipe := source.NewPipeline(fileListPlugin{files: []source.File{
+		&source.BufferFile{
+			BasicFile: source.BasicFile{
+				RelPathStr:    ignoredRel,
+				TargetBaseDir: root,
+				FileMode:      mode,
+				Info:          "module:place (old.md)",
+				FileType:      source.TypeStatic,
+			},
+			Content: content,
+		},
+		&source.BufferFile{
+			BasicFile: source.BasicFile{
+				RelPathStr:    keptRel,
+				TargetBaseDir: root,
+				FileMode:      mode,
+				Info:          "module:place (README.md)",
+				FileType:      source.TypeStatic,
+			},
+			Content: content,
+		},
+	}})
+
+	statePath := filepath.Join(root, ".workspaced", "state.json")
+	store, err := deployer.NewFileStateStore(statePath, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(&deployer.State{Files: map[string]deployer.ManagedInfo{
+		ignoredAbs: {SourceInfo: "module:place (old.md)"},
+		keptAbs:    {SourceInfo: "module:place (README.md)"},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr, err := NewManager(Config{
+		Pipeline:   pipe,
+		StateStore: store,
+		Ignore:     func(target string) bool { return target == ignoredAbs },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, ctx := taskgroup.New(logging.NewWriterContext(t.Output()), taskgroup.DefaultLimits())
+	_ = g
+	result, err := mgr.Apply(ctx, ApplyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.StateDropped != 1 {
+		t.Fatalf("StateDropped=%d want 1", result.StateDropped)
+	}
+	if result.FilesCreated+result.FilesUpdated+result.FilesDeleted != 0 {
+		t.Fatalf("want idle apply, got create=%d update=%d delete=%d",
+			result.FilesCreated, result.FilesUpdated, result.FilesDeleted)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loaded.Files[ignoredAbs]; ok {
+		t.Fatal("gitignored key still in state after idle apply")
+	}
+	if _, ok := loaded.Files[keptAbs]; !ok {
+		t.Fatal("tracked key missing after idle apply")
+	}
+	if _, err := os.Stat(ignoredAbs); err != nil {
+		t.Fatalf("ignored file should stay on disk: %v", err)
+	}
+}

--- a/internal/dotfiles/report.go
+++ b/internal/dotfiles/report.go
@@ -30,8 +30,15 @@ func LogApplyResult(ctx context.Context, result *ApplyResult, opts LogApplyOptio
 	}
 	logger := logging.GetLogger(ctx)
 	hasChanges := result.FilesCreated > 0 || result.FilesUpdated > 0 || result.FilesDeleted > 0 || (opts.ShowNoop && result.FilesNoOp > 0)
+	if result.StateDropped > 0 {
+		msg := "dropped gitignored paths from state"
+		if opts.DryRun {
+			msg = "would drop gitignored paths from state"
+		}
+		logger.Info(msg, "count", result.StateDropped)
+	}
 	if !hasChanges {
-		if opts.NoChangesTarget != "" && !opts.DryRun {
+		if opts.NoChangesTarget != "" && !opts.DryRun && result.StateDropped == 0 {
 			logger.Info("no changes needed", "target", opts.NoChangesTarget)
 		}
 	} else {

--- a/internal/dotfiles/report_test.go
+++ b/internal/dotfiles/report_test.go
@@ -46,6 +46,35 @@ func TestLogApplyResult(t *testing.T) {
 			},
 		},
 		{
+			name:   "codebase idle apply with state drops reports them",
+			result: &ApplyResult{StateDropped: 3},
+			opts: LogApplyOptions{
+				NoChangesTarget: "repo root",
+			},
+			wantContain: []string{
+				"dropped gitignored paths from state",
+				"count=3",
+			},
+			wantAbsent: []string{
+				"no changes needed",
+			},
+		},
+		{
+			name:   "codebase idle plan with state drops reports would-drop",
+			result: &ApplyResult{StateDropped: 2},
+			opts: LogApplyOptions{
+				DryRun:          true,
+				NoChangesTarget: "repo root",
+			},
+			wantContain: []string{
+				"would drop gitignored paths from state",
+				"count=2",
+			},
+			wantAbsent: []string{
+				"no changes needed",
+			},
+		},
+		{
 			name:   "codebase idle plan suppresses idle line",
 			result: &ApplyResult{},
 			opts: LogApplyOptions{

--- a/skills/workspaced/references/plan-and-apply.md
+++ b/skills/workspaced/references/plan-and-apply.md
@@ -76,7 +76,7 @@ If plan is empty but you expected changes:
 - Lock/source resolution not updated
 - Template `skip`/conditionals suppressing output
 - Change only in an untracked file outside module layout
-- Codebase apply: gitignored dests (repo `.gitignore` / `.git/info/exclude`) still create/update on disk but are omitted from `state.json` and are never pruned. Home apply does not use this.
+- Codebase apply: gitignored dests (repo `.gitignore` / `.git/info/exclude`, walking up to the git root) still create/update on disk but are omitted from `state.json` and are never pruned. An older `state.json` keeps those keys until apply (plan only reports the drop). Home apply does not use this.
 
 ## Gotchas
 


### PR DESCRIPTION
## What

Older repos already have a full `.workspaced/state.json`. Adding gitignore dests and running apply with no file diffs still rewrites state and drops those keys. Plan logs `would drop N` without writing.

Ignore matching walks up from the cue dir to the git root.

## Verify

- `go test ./internal/deployer/ ./internal/dotfiles/`